### PR TITLE
Start production-izing Horizon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: artsy/hokusai:0.4.6
+      - image: artsy/hokusai:0.5.0
     steps:
       - add_ssh_keys
       - checkout
@@ -10,7 +10,7 @@ jobs:
       - run: hokusai test
   deploy:
     docker:
-      - image: artsy/hokusai:0.4.6
+      - image: artsy/hokusai:0.5.0
     steps:
       - add_ssh_keys
       - checkout
@@ -18,15 +18,7 @@ jobs:
       - run: hokusai configure --kubectl-version 1.6.3 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
       - run: hokusai registry push --tag $CIRCLE_SHA1 --force --overwrite
       - run: hokusai staging deploy $CIRCLE_SHA1
-      - run: git push git@github.com:artsy/reflection.git $CIRCLE_SHA1:refs/heads/staging --force
-  promote:
-    docker:
-      - image: artsy/hokusai:0.4.6
-    steps:
-      - add_ssh_keys
-      - checkout
-      - run: hokusai configure --kubectl-version 1.6.3 --s3-bucket artsy-citadel --s3-key k8s/config --platform linux
-      - run: hokusai pipeline promote
+      - run: git push git@github.com:artsy/horizon.git $CIRCLE_SHA1:refs/heads/staging --force
 workflows:
   version: 2
   default:
@@ -34,16 +26,10 @@ workflows:
       - test:
           filters:
             branches:
-              ignore:
-                - staging
-                - release
+              ignore: staging
       - deploy:
           filters:
             branches:
               only: master
           requires:
             - test
-      - promote:
-          filters:
-            branches:
-              only: release

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ Horizon
 
 Visual representations of release pipelines.
 
+* State: internal usage
+* Staging (only): [releases.artsy.net](https://releases.artsy.net)
+* GitHub: https://github.com/artsy/horizon
+* Point Team: [Platform](https://artsy.slack.com/messages/product-platform)
+
+
 Design
 ---
 * `Organization`s have many `Project`s
@@ -62,7 +68,7 @@ Deployed manually via [hokusai](https://github.com/artsy/hokusai) to _only_ a st
 TO DO
 ---
 * ~~Support hokusai~~
-* Better visual
+* ~~Better visual~~
 * ~~Allow SSH keys to be configured for each org or project (probably like `git config --local core.sshCommand "ssh -i ~/.ssh/some_key_file"`...). (Maybe not necessary given github/heroku tokens in https URLs)~~
 * ~~sanitize URLs with tokens/credentials in them~~
 * ~~instead of including tokens in each git URL, define "profiles" associated with each organization and project~~


### PR DESCRIPTION
I transferred the repository to the artsy org since this is becoming more of an actively [and collectively] updated thing.

This adds some basic README info and fixes the CircleCI config to automate basic deploys to staging.