### PR TITLE
Bump releasecop to get fix for annotated tags

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'jbuilder', '~> 2.5'
 #gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'acts_as_list' # order Project#stages
-gem 'releasecop', '>= 0.0.13' # compare release stages
+gem 'releasecop', '>= 0.0.14' # compare release stages
 gem 'activeadmin' # manage models
 gem 'redis' # actioncable adapter
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redis (4.0.3)
-    releasecop (0.0.13)
+    releasecop (0.0.14)
       thor
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -254,7 +254,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.1)
   redis
-  releasecop (>= 0.0.13)
+  releasecop (>= 0.0.14)
   rspec-rails
   sass-rails (~> 5.0)
   turbolinks (~> 5)
@@ -266,4 +266,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.2
+   1.17.3


### PR DESCRIPTION
Reaction's new auto-releasing/tagging scheme doesn't play well with how `releasecop` identifies the commit associated with each release tag. The problem seems to be in how it sorts by `committerdate` and `authordate`, but annotated tags don't have those.

[This doc](https://git-scm.com/docs/git-for-each-ref#git-for-each-ref-symref) clarified things:

> For commit and tag objects, the special `creatordate` and `creator` fields will correspond to the appropriate date or name-email-date tuple from the `committer` or `tagger` fields depending on the object type. These are intended for working on a mix of annotated and lightweight tags.

The releasecop fix is: https://github.com/joeyAghion/releasecop/commit/c7eda35994b604e6554bdb55b1a59ff4d6ab1ef2