### PR TITLE
Fix Horizon for latest Hokusai; add error-reporting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'jbuilder', '~> 2.5'
 #gem 'bootsnap', '>= 1.1.0', require: false
 
 gem 'acts_as_list' # order Project#stages
-gem 'releasecop', '>= 0.0.14' # compare release stages
+gem 'releasecop', '>= 0.0.15' # compare release stages
 gem 'activeadmin' # manage models
 gem 'redis' # actioncable adapter
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,7 +178,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redis (4.0.3)
-    releasecop (0.0.14)
+    releasecop (0.0.15)
       thor
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
@@ -254,7 +254,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.1)
   redis
-  releasecop (>= 0.0.14)
+  releasecop (>= 0.0.15)
   rspec-rails
   sass-rails (~> 5.0)
   turbolinks (~> 5)

--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -68,7 +68,7 @@
   .project_status_unknown {
     color: #999;
   }
-  .project_status_warning {
+  .project_status_warning, .project_status_error {
     color: #900;
   }
 }
@@ -151,7 +151,9 @@
   .todo .project a:hover {
     text-decoration: underline;
   }
-
+  .todo .project .error_message {
+    color: #900;
+  }
   .todo .project .stage {
     font-family: "Unica77LLWebMedium";
     font-size: 18px;

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -3,6 +3,7 @@ module ProjectsHelper
   GITHUB_REMOTE_EXPR = /https:\/\/github.com\/(?<org>[^\/]+)\/(?<project>[^\.]+).git/
   STATUS_ICONS = {
     unknown: '?',
+    error: '&#9888;',
     warning: '&#10071;',
     released: '&check;'
   }
@@ -17,7 +18,7 @@ module ProjectsHelper
 
   def project_status_icon(project)
     status = get_status(project)
-    content_tag(:div, class: "project_status project_status_#{status}") do
+    content_tag(:div, class: "project_status project_status_#{status}", title: project.snapshot&.error_message) do
       raw(STATUS_ICONS[status])
     end
   end
@@ -28,6 +29,7 @@ module ProjectsHelper
 
   def get_status(project)
     return :unknown if project.snapshot.nil?
+    return :error if project.snapshot.error_message.present?
     return :released if project.snapshot&.comparisons&.all?(&:released?)
     :warning
   end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -5,7 +5,7 @@ class Project < ApplicationRecord
   belongs_to :snapshot, optional: true
 
   def fully_released?
-    !!snapshot&.comparisons&.all?(&:released?)
+    snapshot && snapshot.error_message.nil? && snapshot.comparisons.all?(&:released?)
   end
 
   def total_comparison_size

--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -35,7 +35,7 @@ class ComparisonService
         dir
       )
       refreshed_at = Time.now
-      result = checker.check # build comparisons
+      result = ResultWrapper.new(checker) # build comparisons
       if project.snapshot && equivalent_snapshots?(project.snapshot, result)
         project.snapshot.update!(refreshed_at: refreshed_at)
       else
@@ -47,6 +47,22 @@ class ComparisonService
   end
 
   private
+
+  class ResultWrapper
+    attr_accessor :result, :error
+
+    def initialize(checker)
+      begin
+        @result = checker.check
+      rescue => ex
+        self.error = ex
+      end
+    end
+
+    def comparisons
+      @result&.comparisons || []
+    end
+  end
 
   def build_manifest_item(stage)
     {
@@ -61,21 +77,22 @@ class ComparisonService
   end
 
   def equivalent_snapshots?(snapshot, result)
-    snapshot.comparisons.order(position: :asc).map(&:description) == result.comparisons.map(&:lines)
+    snapshot.comparisons.order(position: :asc).map(&:description) == result.comparisons.map(&:lines) &&
+    snapshot.error_message == result.error&.message
   end
 
   def store_new_snapshot!(project, result, refreshed_at)
-    project.snapshots.create!(refreshed_at: refreshed_at).tap do |snapshot|
-      result.comparisons.each do |c|
-        snapshot.comparisons.create!(
-          behind_stage: project.stages.detect { |s| s.name == c.behind.name },
-          ahead_stage: project.stages.detect { |s| s.name == c.ahead.name },
-          released: !c.unreleased?,
-          description: c.lines
-        )
-      end
-      project.update(snapshot: snapshot)
+    snapshot = project.snapshots.create!(refreshed_at: refreshed_at, error_message: result.error&.message)
+    result.comparisons.each do |c|
+      snapshot.comparisons.create!(
+        behind_stage: project.stages.detect { |s| s.name == c.behind.name },
+        ahead_stage: project.stages.detect { |s| s.name == c.ahead.name },
+        released: !c.unreleased?,
+        description: c.lines
+      )
     end
+    project.update(snapshot: snapshot)
+    snapshot
   end
 
   def clean_up_old_snapshots

--- a/app/views/projects/_index_dashboard.html.erb
+++ b/app/views/projects/_index_dashboard.html.erb
@@ -6,6 +6,7 @@
       <div class="project <%= healthy_count_class project.total_comparison_size %>">
         <h2><%= project.name.titleize %></h2>
         <p><%= project.description %></p>
+        <div class="error_message"><%= project.snapshot&.error_message %></div>
         <div class="comparisons">
           <% project.stages.ordered.each_cons(2) do |ahead, behind| %>
             <% if comparison = project.snapshot&.comparisons&.detect{ |c| c.behind_stage_id == behind.id && c.ahead_stage_id == ahead.id } %>

--- a/db/migrate/20190405023407_add_error_message_to_snapshot.rb
+++ b/db/migrate/20190405023407_add_error_message_to_snapshot.rb
@@ -1,0 +1,5 @@
+class AddErrorMessageToSnapshot < ActiveRecord::Migration[5.2]
+  def change
+    add_column :snapshots, :error_message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_12_10_152218) do
+ActiveRecord::Schema.define(version: 2019_04_05_023407) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -62,6 +62,7 @@ ActiveRecord::Schema.define(version: 2018_12_10_152218) do
     t.datetime "refreshed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "error_message"
     t.index ["project_id"], name: "index_snapshots_on_project_id"
   end
 


### PR DESCRIPTION
There were a number of recent changes to the output and behavior of `hokusai registry images`, so I had to update `releasecop` to accommodate the new formatting here: https://github.com/joeyAghion/releasecop/commit/57ee7ae566b1570e2fde627517241e3835900565

This PR upgrades `releasecop` to take advantage of these fixes for hokusai v0.5.4.

Also, the whole cron step that _checks_ each project has proven to be very brittle since it depends on specific project configurations and external tools like `git` and `hokusai` which occasionally change or break. This updates the cron to recover from errors during each check step, store the error (if any), and render it on the front end for greater visibility. It looks like:

<img  alt="Screen Shot 2019-04-04 at 11 15 30 PM" src="https://user-images.githubusercontent.com/28120/55601662-feb70f00-572f-11e9-881d-10df337cbe13.png">


(error message is visible if you hover over the icon). And:

<img alt="Screen Shot 2019-04-04 at 11 16 13 PM" src="https://user-images.githubusercontent.com/28120/55601685-11c9df00-5730-11e9-8fd1-5c94726d0e11.png">
