### PR TITLE
Avoid violating foreign key constraints when projects are deleted

### DIFF
--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -1,6 +1,7 @@
 class Snapshot < ApplicationRecord
   belongs_to :project
   has_many :comparisons, dependent: :destroy
+  has_one :current_snapshot_for_project, class_name: 'Project', dependent: :nullify # useful for cleaning up Project#snapshot references on destroy
 
   def total_comparison_size
     comparisons.map(&:comparison_size).sum

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -1,12 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe Organization, type: :model do
+RSpec.describe Project, type: :model do
   it 'can be deleted despite associations' do
     org = Organization.create!(name: 'artsy')
     project = org.projects.create!(name: 'eigen')
     stages = (1..2).map {|i| project.stages.create!(name: "stage #{i}", git_remote: 'https://github.com/artsy/eigen.git') }
     snapshot = project.snapshots.create!
     comparison = snapshot.comparisons.create!(ahead_stage: stages.first, behind_stage: stages.last)
-    expect(org.destroy).to be_present
+    project.update(snapshot: snapshot)
+    expect(project.destroy).to be_present
   end
 end


### PR DESCRIPTION
`Project`s have a `has_many` association to all of the available `Snapshot`s, but also store a single reference to the current one (`belongs_to :snapshot`). This gets funky when deleting a project, which cascades to the snapshots, which temporarily violates the reference from the project. With this change, that `snapshot_id` column is `NULL`-ified within the transaction to avoid the violation.