### PR TITLE
@ashkan18: Allow projects to be tagged and allow filtering the dashboard to those tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,5 +68,5 @@ TO DO
 * button to refresh project on-demand
 * ~~Fix ugly AWS credentials -> hokusai flow~~
 * ~~Make errors [when refreshing projects] visible and avoid short-circuiting entire cron~~
-* Make sorting and classifying of projects more sophisticated (penalize staleness and not just number of commits)
-
+* Make sorting and classifying of projects more sophisticated (penalize staleness and number of contributors and not just number of commits)
+* ~~Add tags to projects and enable filtering dashboard/list view by them~~

--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -17,5 +17,15 @@ ActiveAdmin.register Project do
     end
   end
 
-  permit_params :organization_id, :name, :description
+  permit_params :organization_id, :name, :description, :tags_input
+
+  form do |f|
+    f.inputs do
+        f.input :organization
+        f.input :name
+        f.input :description
+        f.input :tags_input, label: 'Tags (JSON array)'
+    end
+    f.actions
+  end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -3,7 +3,9 @@ class ProjectsController < ApplicationController
 
   def index
     @organization_id = projects_params[:organization_id]
-    @projects = Project.where(projects_params).sort_by do |project|
+    @projects = Project.where(projects_params)
+    @projects = @projects.where('tags ?| array[:tags]', tags: params[:tags]) if params[:tags]&.any?
+    @projects.sort_by do |project|
       [project.fully_released? ? 1 : 0, project.name]
     end
     @view = VIEWS.include?(params[:view]) ? params[:view] : 'detail'

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,8 +1,12 @@
 class Project < ApplicationRecord
+  include JsonbEditable
+
   belongs_to :organization
   has_many :stages, dependent: :destroy
   has_many :snapshots, dependent: :destroy
   belongs_to :snapshot, optional: true
+
+  jsonb_editable :tags
 
   def fully_released?
     snapshot && snapshot.error_message.nil? && snapshot.comparisons.all?(&:released?)

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -4,6 +4,9 @@
       <%= org.name %>:
       <%= link_to 'detail', projects_path(organization_id: org.id) %> / 
       <%= link_to 'dashboard', projects_path(organization_id: org.id, view: 'dashboard') %>
+      <% if (tags = org.projects.pluck(:tags).flatten.uniq.sort).any? %>
+        (tags: <%=raw tags.map { |tag| link_to tag, projects_path(organization_id: org.id, view: 'dashboard', tags: [tag]) }.join(', ') %>)
+      <% end %>
     </li>
   <% end %>
 </ul>

--- a/db/migrate/20190531194338_add_tags_to_projects.rb
+++ b/db/migrate/20190531194338_add_tags_to_projects.rb
@@ -1,0 +1,5 @@
+class AddTagsToProjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :projects, :tags, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_05_023407) do
+ActiveRecord::Schema.define(version: 2019_05_31_194338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 2019_04_05_023407) do
     t.datetime "updated_at", null: false
     t.bigint "snapshot_id"
     t.string "description"
+    t.jsonb "tags"
     t.index ["organization_id"], name: "index_projects_on_organization_id"
     t.index ["snapshot_id"], name: "index_projects_on_snapshot_id"
   end


### PR DESCRIPTION
Once I started investigating how to make the sorting more sophisticated, I realized how it would require completely replacing `releasecop` with a more structured, programmatic alternative.

This to-do about adding tags to projects seemed much easier.