### PR TITLE
Deploy blockers API #FF

### DIFF
--- a/app/controllers/API/deploy_blocks_controller.rb
+++ b/app/controllers/API/deploy_blocks_controller.rb
@@ -1,0 +1,27 @@
+class API::DeployBlocksController < ApplicationController
+  def index
+    project = Project.find(params[:project_id])
+    coerced_resolved_param =
+      ActiveModel::Type::Boolean.new.cast(params[:resolved])
+
+    scoped_deploy_blocks = filter_by_resolved(
+      project.deploy_blocks,
+      coerced_resolved_param
+    )
+
+    render json: scoped_deploy_blocks
+  end
+
+  private
+
+  def filter_by_resolved(deploy_blocks, resolved_query_param)
+    case resolved_query_param
+    when true
+      deploy_blocks.resolved
+    when false
+      deploy_blocks.unresolved
+    else
+      deploy_blocks
+    end
+  end
+end

--- a/app/controllers/api/deploy_blocks_controller.rb
+++ b/app/controllers/api/deploy_blocks_controller.rb
@@ -1,4 +1,4 @@
-class API::DeployBlocksController < ApplicationController
+class Api::DeployBlocksController < ApplicationController
   def index
     project = Project.find(params[:project_id])
     coerced_resolved_param =

--- a/app/models/deploy_block.rb
+++ b/app/models/deploy_block.rb
@@ -1,0 +1,6 @@
+class DeployBlock < ApplicationRecord
+  belongs_to :project
+
+  scope :unresolved, -> { where(resolved_at: nil) }
+  scope :resolved, -> { where.not(resolved_at: nil) }
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,6 +4,7 @@ class Project < ApplicationRecord
   belongs_to :organization
   has_many :stages, dependent: :destroy
   has_many :snapshots, dependent: :destroy
+  has_many :deploy_blocks
   belongs_to :snapshot, optional: true
 
   jsonb_editable :tags

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -14,3 +14,7 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'API'
+end

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -15,6 +15,6 @@
 #   inflect.acronym 'RESTful'
 # end
 
-ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.acronym 'API'
-end
+# ActiveSupport::Inflector.inflections(:en) do |inflect|
+#   inflect.acronym 'API'
+# end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,12 @@
 Rails.application.routes.draw do
+
   ActiveAdmin.routes(self)
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root to: 'organizations#index'
   resources :projects, only: [:index]
   get 'projects/:organization_id/dashboard', to: 'projects#simple'
+
+  namespace 'api' do
+    resources :deploy_blocks, only: [:index]
+  end
 end

--- a/db/migrate/20190808162808_create_deploy_blocks.rb
+++ b/db/migrate/20190808162808_create_deploy_blocks.rb
@@ -1,0 +1,11 @@
+class CreateDeployBlocks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :deploy_blocks do |t|
+      t.references :project, foreign_key: true, index: true
+      t.datetime :resolved_at
+      t.text :description
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_194338) do
+ActiveRecord::Schema.define(version: 2019_08_08_162808) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,6 +27,15 @@ ActiveRecord::Schema.define(version: 2019_05_31_194338) do
     t.index ["ahead_stage_id"], name: "index_comparisons_on_ahead_stage_id"
     t.index ["behind_stage_id"], name: "index_comparisons_on_behind_stage_id"
     t.index ["snapshot_id"], name: "index_comparisons_on_snapshot_id"
+  end
+
+  create_table "deploy_blocks", force: :cascade do |t|
+    t.bigint "project_id"
+    t.datetime "resolved_at"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["project_id"], name: "index_deploy_blocks_on_project_id"
   end
 
   create_table "organizations", force: :cascade do |t|
@@ -85,6 +94,7 @@ ActiveRecord::Schema.define(version: 2019_05_31_194338) do
   add_foreign_key "comparisons", "snapshots"
   add_foreign_key "comparisons", "stages", column: "ahead_stage_id"
   add_foreign_key "comparisons", "stages", column: "behind_stage_id"
+  add_foreign_key "deploy_blocks", "projects"
   add_foreign_key "profiles", "organizations"
   add_foreign_key "projects", "organizations"
   add_foreign_key "projects", "snapshots"

--- a/lib/exceptions_test_helper.rb
+++ b/lib/exceptions_test_helper.rb
@@ -1,0 +1,36 @@
+module ExceptionsTestHelper
+  # enables the exceptions app in the block.
+  #
+  # Rspec:
+  #
+  #   it "shows an error page" do
+  #     with_exceptions_app do
+  #       get '/'
+  #     end
+  #
+  #     ...
+  #   end
+  #
+  # Minitest:
+  #
+  #   test "it shows an error page" do
+  #     with_exceptions_app do
+  #       get '/'
+  #     end
+  #
+  #     ...
+  #   end
+  #
+  def with_exceptions_app(enabled: true)
+    org_show_detailed_exceptions = Rails.application.env_config['action_dispatch.show_detailed_exceptions']
+    org_show_exceptions = Rails.application.env_config['action_dispatch.show_exceptions']
+
+    Rails.application.env_config['action_dispatch.show_detailed_exceptions'] = !enabled
+    Rails.application.env_config['action_dispatch.show_exceptions'] = enabled
+
+    yield
+  ensure
+    Rails.application.env_config['action_dispatch.show_detailed_exceptions'] = org_show_detailed_exceptions
+    Rails.application.env_config['action_dispatch.show_exceptions'] = org_show_exceptions
+  end
+end

--- a/spec/features/deployability_api_spec.rb
+++ b/spec/features/deployability_api_spec.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'exceptions_test_helper'
+
+RSpec.feature 'an API to know whether a project is a deployable', type: :request do
+  include ExceptionsTestHelper
+
+  describe 'GET /api/projects/:id/deployability' do
+    context 'when we do not pass any resolved parameter' do
+      it 'does not filter by resolved, but still filters by partner id' do
+        artsy = Organization.create!(name: 'Artsy')
+        shipping = artsy.projects.create!(name: 'shipping')
+        packing = artsy.projects.create!(name: 'packing')
+        unresolved_shipping_deploy_block = DeployBlock.create!(project: shipping)
+        resolved_shipping_deploy_block = DeployBlock.create!(
+          project: shipping,
+          resolved_at: DateTime.current
+        )
+        unresolved_packing_deploy_block = DeployBlock.create(project: packing)
+        resolved_packing_deploy_block = DeployBlock.create(
+          project: packing,
+          resolved_at: DateTime.now
+        )
+
+        headers = { 'ACCEPT' => 'application/json' }
+        get "/api/deploy_blocks?project_id=#{shipping.id}", headers: headers
+        expect(response.body).to eq(
+          [unresolved_shipping_deploy_block, resolved_shipping_deploy_block].to_json
+        )
+      end
+    end
+    context 'when querying for resolved deploy blocks' do
+      it 'only returns resolved, not unresolved, for the given project' do
+        artsy = Organization.create!(name: 'Artsy')
+        shipping = artsy.projects.create!(name: 'shipping')
+        packing = artsy.projects.create!(name: 'packing')
+        unresolved_shipping_deploy_block = DeployBlock.create!(project: shipping)
+        resolved_shipping_deploy_block = DeployBlock.create!(
+          project: shipping,
+          resolved_at: DateTime.current
+        )
+        unresolved_packing_deploy_block = DeployBlock.create(project: packing)
+        resolved_packing_deploy_block = DeployBlock.create(
+          project: packing,
+          resolved_at: DateTime.now
+        )
+
+        headers = { 'ACCEPT' => 'application/json' }
+        get "/api/deploy_blocks?project_id=#{shipping.id}&resolved=true", headers: headers
+
+        expect(response.body).to eq([resolved_shipping_deploy_block].to_json)
+      end
+    end
+    context 'when querying for unresolved deploy blocks' do
+      it 'returns 200 SUCCESS and an empty response if there are no unresolved blocks' do
+        artsy = Organization.create!(name: 'Artsy')
+        shipping = artsy.projects.create!(name: 'shipping')
+
+        headers = { 'ACCEPT' => 'application/json' }
+        get "/api/deploy_blocks?project_id=#{shipping.id}&resolved=false", headers: headers
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to eq("[]")
+      end
+
+      context 'with unresolved deploy blocks' do
+        it 'returns 200 SUCCESS and the deploy block in the response' do
+          artsy = Organization.create!(name: 'Artsy')
+          shipping = artsy.projects.create!(name: 'shipping')
+          shipping_deploy_block = DeployBlock.create!(project: shipping)
+
+          headers = { 'ACCEPT' => 'application/json' }
+          get "/api/deploy_blocks?project_id=#{shipping.id}&resolved=false", headers: headers
+
+          expect(response.body).to eq([shipping_deploy_block].to_json)
+        end
+
+        it 'only returns deploy blocks for the project' do
+          artsy = Organization.create!(name: 'Artsy')
+          shipping = artsy.projects.create!(name: 'shipping')
+          packing = artsy.projects.create!(name: 'packing')
+          shipping_deploy_block = DeployBlock.create!(project: shipping)
+          packing_deploy_block = DeployBlock.create!(project: packing)
+
+          headers = { 'ACCEPT' => 'application/json' }
+          get "/api/deploy_blocks?project_id=#{shipping.id}&resolved=false", headers: headers
+
+          expect(response.body).to eq([shipping_deploy_block].to_json)
+        end
+      end
+
+      context 'with resolved deploy blocks' do
+        it 'only returns the unresolved deploy blocks, and not resolved ones' do
+          artsy = Organization.create!(name: 'Artsy')
+          shipping = artsy.projects.create!(name: 'shipping')
+          packing = artsy.projects.create!(name: 'packing')
+          unresolved_deploy_block = DeployBlock.create!(project: shipping)
+          resolved_deploy_block = DeployBlock.create!(
+            project: shipping,
+            resolved_at: DateTime.current
+          )
+
+          headers = { 'ACCEPT' => 'application/json' }
+          get "/api/deploy_blocks?project_id=#{shipping.id}&resolved=false", headers: headers
+
+          expect(JSON.parse(response.body).count).to eq(1)
+
+          expect(
+            JSON.parse(response.body).map { |payload| payload['id'] }
+          ).to eq([unresolved_deploy_block.id])
+        end
+      end
+    end
+
+    it 'returns a 404 if requesting for a project that does not exist' do
+      with_exceptions_app do
+        headers = { 'ACCEPT' => 'application/json' }
+        get "/api/deploy_blocks?project_id=-2&resolved=false", headers: headers
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Create an API that allows us to know if a deploy is blocked.

Right now, there is no explicit UI for creating a deploy block, nor is
there an dashboard visual for when a service is blocked, but the API is
in place.

Co-authored-by: Justin Bennett <zephraph@gmail.com>

https://trello.com/c/KwgiGZRp

<img width="1552" alt="local-deploy-blocks-api-working" src="https://user-images.githubusercontent.com/1561546/62736930-9db08800-b9fc-11e9-95ea-ee18184dfbd4.png">
