### PR TITLE
Minor refactors

### DIFF
--- a/app/models/deploy_strategy.rb
+++ b/app/models/deploy_strategy.rb
@@ -16,6 +16,7 @@ class DeployStrategy < ApplicationRecord
 
   jsonb_editable :arguments
 
+  # Prefer a `repo` argument, but fall back to org and project names otherwise.
   def github_repo
     arguments['repo'] || [stage.project.organization.name, stage.project.name].join('/')
   end
@@ -23,7 +24,7 @@ class DeployStrategy < ApplicationRecord
   private
 
   def validate_arguments
-    return unless PROVIDERS.include?(provider)
+    return unless PROVIDERS.include?(provider) # don't bother if provider invalid
 
     unless REQUIRED_ARGUMENTS[provider].all? { |a| (arguments || {}).keys.include?(a) }
       errors.add(:arguments, "must include #{REQUIRED_ARGUMENTS[provider].to_sentence}")

--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -28,7 +28,7 @@ class ComparisonService
 
   def refresh_comparisons
     refreshed_at = Time.now
-    result = perform_comparison
+    result = ReleasecopService.new(project).perform_comparison
     new_snapshot = nil
     if project.snapshot && equivalent_snapshots?(project.snapshot, result)
       project.snapshot.update!(refreshed_at: refreshed_at)
@@ -51,45 +51,6 @@ class ComparisonService
       c.behind_stage == stage
     end
     comparison && comparison.comparison_size > 10
-  end
-
-  def perform_comparison
-    Dir.mktmpdir(['releasecop', project.name]) do |dir|
-      checker = Releasecop::Checker.new(
-        project.name,
-        project.stages.order(position: :asc).map{|s| build_manifest_item(s) },
-        dir
-      )
-      ResultWrapper.new(checker) # build comparisons
-    end
-  end
-
-  class ResultWrapper
-    attr_accessor :result, :error
-
-    def initialize(checker)
-      begin
-        @result = checker.check
-      rescue => ex
-        self.error = ex
-      end
-    end
-
-    def comparisons
-      @result&.comparisons || []
-    end
-  end
-
-  def build_manifest_item(stage)
-    {
-      'name' => stage.name,
-      'git' => construct_git(stage),
-      'tag_pattern' => stage.tag_pattern.presence,
-      'branch' => stage.branch.presence,
-      'hokusai' => stage.hokusai.presence,
-      'aws_access_key_id' => stage.profile&.environment&.fetch('AWS_ACCESS_KEY_ID'),
-      'aws_secret_access_key' => stage.profile&.environment&.fetch('AWS_SECRET_ACCESS_KEY')
-    }
   end
 
   def equivalent_snapshots?(snapshot, result)
@@ -115,16 +76,5 @@ class ComparisonService
     ids = project.snapshots.pluck(:id).sort
     return unless ids.size > KEEP_OLD_SNAPSHOTS
     project.snapshots.where('id < ?', ids[-KEEP_OLD_SNAPSHOTS]).destroy_all
-  end
-
-  def construct_git(stage)
-    if stage.profile&.basic_username || stage.profile&.basic_password
-      uri = URI(stage.git_remote)
-      uri.user = stage.profile&.basic_username
-      uri.password = stage.profile&.basic_password
-      uri.to_s
-    else
-      stage.git_remote
-    end
   end
 end

--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -50,7 +50,7 @@ class ComparisonService
     comparison = stage.project.snapshot.comparisons.detect do |c|
       c.behind_stage == stage
     end
-    comparison && comparison.comparison_size >= 10
+    comparison && comparison.comparison_size > 10
   end
 
   def perform_comparison

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -8,7 +8,7 @@ class DeployService
 
   def self.create_github_pull_request(deploy_strategy)
     access_token = deploy_strategy.profile&.basic_password
-    raise 'profile.basic_password is required for Github authentication' if access_token.blank?
+    raise 'A profile and basic_password are required for Github authentication' if access_token.blank?
 
     client = Octokit::Client.new(access_token: access_token)
     begin

--- a/app/services/releasecop_service.rb
+++ b/app/services/releasecop_service.rb
@@ -1,0 +1,7 @@
+class ReleasecopService
+  LOG_LINE_EXPR = /^(?<sha>[0-9a-f]+) (?<date>[0-9\-]+) (?<message>.*) \((?<name>.*), (?<email>.*)\)\w*$/ # %h %ad %s (%an, %ae)
+
+  def self.parsed_log_line(line)
+    line.match(LOG_LINE_EXPR)&.named_captures || {}
+  end
+end

--- a/app/services/releasecop_service.rb
+++ b/app/services/releasecop_service.rb
@@ -1,7 +1,66 @@
 class ReleasecopService
+  attr_accessor :project
+
   LOG_LINE_EXPR = /^(?<sha>[0-9a-f]+) (?<date>[0-9\-]+) (?<message>.*) \((?<name>.*), (?<email>.*)\)\w*$/ # %h %ad %s (%an, %ae)
 
   def self.parsed_log_line(line)
     line.match(LOG_LINE_EXPR)&.named_captures || {}
   end
+
+  def initialize(project)
+    @project = project
+  end
+
+  def perform_comparison
+    Dir.mktmpdir(['releasecop', project.name]) do |dir|
+      checker = Releasecop::Checker.new(
+        project.name,
+        project.stages.order(position: :asc).map { |s| build_manifest_item(s) },
+        dir
+      )
+      ResultWrapper.new(checker) # build comparisons
+    end
+  end
+
+  class ResultWrapper
+    attr_accessor :result, :error
+
+    def initialize(checker)
+      begin
+        @result = checker.check
+      rescue => ex
+        self.error = ex
+      end
+    end
+
+    def comparisons
+      @result&.comparisons || []
+    end
+  end
+
+  private
+
+  def construct_git(stage)
+    if stage.profile&.basic_username || stage.profile&.basic_password
+      uri = URI(stage.git_remote)
+      uri.user = stage.profile&.basic_username
+      uri.password = stage.profile&.basic_password
+      uri.to_s
+    else
+      stage.git_remote
+    end
+  end
+
+  def build_manifest_item(stage)
+    {
+      'name' => stage.name,
+      'git' => construct_git(stage),
+      'tag_pattern' => stage.tag_pattern.presence,
+      'branch' => stage.branch.presence,
+      'hokusai' => stage.hokusai.presence,
+      'aws_access_key_id' => stage.profile&.environment&.fetch('AWS_ACCESS_KEY_ID'),
+      'aws_secret_access_key' => stage.profile&.environment&.fetch('AWS_SECRET_ACCESS_KEY')
+    }
+  end
+
 end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Deploys", type: :feature do
     )
     expect {
       DeployService.start(invalid_strategy)
-    }.to raise_error('profile.basic_password is required for Github authentication')    
+    }.to raise_error('A profile and basic_password are required for Github authentication')
   end
 
   it "Sends an Octokit request to create pull request when initializing a client" do


### PR DESCRIPTION
* Combined some test stubs.
* `ComparisonService` was getting big, so I moved all the helpers that were specific to interacting with `releasecop` and parsing its output into a dedicated service class. This also became useful in the view helpers.
* Adjusted the deploy threshold to `> 10` commits to match the dashboard treatment.