### PR TITLE
@mzikherman: Determine deploy severity based on commits, contributors, and age

### DIFF
--- a/spec/services/comparison_service_spec.rb
+++ b/spec/services/comparison_service_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe ComparisonService, type: :model do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe 'severity_score' do
+    before do
+      travel_to Time.zone.local(2019, 8, 2, 11, 11, 11)
+    end
+
+    let(:one_recent_commit_score) do
+      ComparisonService.severity_score([
+        { email: 'foo@bar.com', date: '2019-08-01' }
+      ])
+    end
+
+    let(:one_semirecent_commit_score) do
+      ComparisonService.severity_score([
+        { email: 'foo@bar.com', date: '2019-07-31' }
+      ])
+    end
+
+    let(:one_week_old_commit_score) do
+      ComparisonService.severity_score([
+        { email: 'foo@bar.com', date: '2019-07-25' }
+      ])
+    end
+
+    let(:one_recent_contributor_score) do
+      ComparisonService.severity_score([
+        { email: 'foo@bar.com', date: '2019-08-01' },
+        { email: 'foo@bar.com', date: '2019-08-02' }
+      ])
+    end
+
+    let(:two_recent_contributors_score) do
+      ComparisonService.severity_score([
+        { email: 'foo@bar.com', date: '2019-08-01' },
+        { email: 'baz@bar.com', date: '2019-08-02' }
+      ])
+    end
+
+    let(:two_old_contributors_score) do
+      ComparisonService.severity_score([
+        { email: 'foo@bar.com', date: '2019-07-20' },
+        { email: 'baz@bar.com', date: '2019-07-19' }
+      ])
+    end
+
+    it 'is 0 for no changes' do
+      expect(ComparisonService.severity_score([])).to eq(0)
+    end
+
+    it 'is higher for more contributors' do
+      expect(two_recent_contributors_score).to be > one_recent_contributor_score
+    end
+
+    it 'is higher for old commits' do
+      expect(two_old_contributors_score).to be > two_recent_contributors_score
+    end
+
+    it 'doubles for each week old' do
+      expect(one_semirecent_commit_score).to be > one_recent_commit_score
+      expect(one_week_old_commit_score).to be > (2 * one_recent_commit_score)
+    end
+  end
+end


### PR DESCRIPTION
Took a stab at a slightly more sophisticated way of determining deploy "severity."

This penalizes based on:
* number of commits
* number of distinct contributors
* age of oldest work, in days

To do (later):
* [] Update dashboard treatment to match new logic.
* [] Consider parameterizing `releasecop`'s behavior so we can see merge commits in its output. This would allow us to count PRs instead of commits, which would be slightly more meaningful.

I stuck with our existing threshold of `10` for deciding a diff warrants a deploy. This means:
* one commit by a single contributor will qualify after ~3 days
* one commit each by 2 contributors will qualify after ~2 days
* one commit each by 3 contributors will qualify immediately

However the "age" isn't a perfect measure since it corresponds with when the commit was authored, not when it was merged. We might want to increase the threshold to account for that. See the chart for alternatives:

![](https://cl.ly/1c23a47f203a/Screen%20Shot%202019-08-09%20at%205.24.55%20PM.png)