### PR TITLE
Refactor view logic and memo-ization into ProjectsPresenter

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,19 +1,5 @@
 class ProjectsController < ApplicationController
-  VIEWS = %w[detail dashboard]
-
   def index
-    @organization_id = projects_params[:organization_id]
-    @projects = Project.where(projects_params)
-    @projects = @projects.where('tags ?| array[:tags]', tags: params[:tags]) if params[:tags]&.any?
-    @projects.sort_by do |project|
-      [project.fully_released? ? 1 : 0, project.name]
-    end
-    @view = VIEWS.include?(params[:view]) ? params[:view] : 'detail'
-  end
-
-  private
-
-  def projects_params
-    params.permit(:organization_id)
+    @presenter = ProjectsPresenter.new(params)
   end
 end

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -8,7 +8,7 @@ module ProjectsHelper
   }
 
   def render_log_line(project, line)
-    github_match = project.stages.ordered.first&.git_remote&.match(GITHUB_REMOTE_EXPR)
+    github_match = project.ordered_stages.first&.git_remote&.match(GITHUB_REMOTE_EXPR)
     return line unless github_match
     parsed_line = ReleasecopService.parsed_log_line(line)
     link = link_to parsed_line[:sha], "https://github.com/#{github_match[:org]}/#{github_match[:project]}/commit/#{parsed_line[:sha]}"

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,12 +8,4 @@ class Project < ApplicationRecord
   belongs_to :snapshot, optional: true
 
   jsonb_editable :tags
-
-  def fully_released?
-    snapshot && snapshot.error_message.nil? && snapshot.comparisons.all?(&:released?)
-  end
-
-  def total_comparison_size
-    snapshot&.total_comparison_size || 0
-  end
 end

--- a/app/models/snapshot.rb
+++ b/app/models/snapshot.rb
@@ -2,8 +2,4 @@ class Snapshot < ApplicationRecord
   belongs_to :project
   has_many :comparisons, dependent: :destroy
   has_one :current_snapshot_for_project, class_name: 'Project', dependent: :nullify # useful for cleaning up Project#snapshot references on destroy
-
-  def total_comparison_size
-    comparisons.map(&:comparison_size).sum
-  end
 end

--- a/app/presenters/projects_presenter.rb
+++ b/app/presenters/projects_presenter.rb
@@ -1,0 +1,62 @@
+class ProjectsPresenter
+  VIEWS = %w[detail dashboard]
+
+  def initialize(params)
+    @params = params
+  end
+
+  def detailed_projects
+    projects.sort_by { |p| [p.fully_released? ? 1 : 0, p.name] }
+  end
+
+  def unreleased_projects
+    projects.reject(&:fully_released?).sort_by(&:severity).reverse
+  end
+
+  def released_projects
+    projects.select(&:fully_released?).sort_by(&:name)
+  end
+
+  def view
+    VIEWS.include?(@params[:view]) ? @params[:view] : 'detail'
+  end
+
+  class ProjectWrapper
+    attr_accessor :project
+    delegate :name, :snapshot, :id, :description, to: :project
+
+    def initialize(project)
+      @project = project
+    end
+
+    def ordered_stages
+      @ordered_stages ||= project.stages.sort_by(&:position)
+    end
+
+    def fully_released?
+      snapshot && severity == 0
+    end
+
+    def severity
+      compared_stages.map(&:last).compact.max || 0
+    end
+
+    # enumerates pairs of stages, the corresponding comparison object, and severity score
+    def compared_stages
+      @compared_stages ||= ordered_stages.each_cons(2).map do |ahead, behind|
+        comparison = snapshot&.comparisons&.detect{ |c| c.behind_stage_id == behind.id && c.ahead_stage_id == ahead.id }
+        [ahead, behind, comparison, (ComparisonService.comparison_score(comparison) if comparison)]
+      end
+    end
+  end
+
+  private
+
+  def projects
+    @projects ||= begin
+      query = Project.includes(:stages, snapshot: [:comparisons]).where(@params.permit(:organization_id))
+      query = query.where('tags ?| array[:tags]', tags: @params[:tags]) if @params[:tags]&.any?
+      query.map { |p| ProjectWrapper.new(p) }
+    end
+  end
+end

--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -17,7 +17,11 @@ class ComparisonService
     new_snapshots
   end
 
-  def self.parsed(comparison)
+  def self.comparison_score(comparison)
+    severity_score(parsed_commits(comparison))
+  end
+
+  def self.parsed_commits(comparison)
     comparison.description.map { |l| ReleasecopService.parsed_log_line(l) }
   end
 
@@ -66,8 +70,7 @@ class ComparisonService
     end
     return false unless comparison
 
-    commits = self.class.parsed(comparison)
-    self.class.severity_score(commits) > DEPLOY_AT_SEVERITY
+    self.class.comparison_score(comparison) > DEPLOY_AT_SEVERITY
   end
 
   def equivalent_snapshots?(snapshot, result)

--- a/app/views/projects/_index_dashboard.html.erb
+++ b/app/views/projects/_index_dashboard.html.erb
@@ -2,15 +2,15 @@
   <h1>Out of sync</h1>
 
   <div class="todo">
-    <% @projects.reject(&:fully_released?).sort_by(&:total_comparison_size).reverse.each do |project| %>
-      <div class="project <%= healthy_count_class project.total_comparison_size %>">
+    <% @presenter.unreleased_projects.each do |project| %>
+      <div class="project <%= healthy_count_class(project.severity) %>">
         <h2><%= project.name.titleize %></h2>
         <p><%= project.description %></p>
         <div class="error_message"><%= project.snapshot&.error_message %></div>
         <div class="comparisons">
-          <% project.stages.ordered.each_cons(2) do |ahead, behind| %>
-            <% if comparison = project.snapshot&.comparisons&.detect{ |c| c.behind_stage_id == behind.id && c.ahead_stage_id == ahead.id } %>
-              <div class="comparison <%= healthy_count_class comparison.comparison_size %>">
+          <% project.compared_stages.each do |ahead, behind, comparison, severity| %>
+            <% if comparison %>
+              <div class="comparison <%= healthy_count_class(severity) %>">
                 <div class="stage">
                   <div class="circle"></div>
                   <%= behind.name.titleize %><br />
@@ -21,7 +21,7 @@
                   <% else %>
                     <%= link_to \
                       "#{pluralize(comparison.description.length, 'commit')} behind",
-                      params.permit(:organization_id).merge(view: 'detail', anchor: project_anchor(project)),
+                      params.permit(:organization_id, :view).merge(view: 'detail', anchor: project_anchor(project)),
                       'data-turbolinks' => false
                     %>
                   <% end %>
@@ -40,7 +40,7 @@
   <h1 style="padding-top:30px;">Up to date</h1>
 
   <div class="released">
-    <% @projects.select(&:fully_released?).each do |project| %>
+    <% @presenter.released_projects.each do |project| %>
       <div class="released-project">
       <h2><div class="circle green"></div><%= project.name.titleize %></h2>
       <p><%= project.description %></p>

--- a/app/views/projects/_index_detail.html.erb
+++ b/app/views/projects/_index_detail.html.erb
@@ -1,5 +1,5 @@
 <div class="projects_detail">
-  <% @projects.each do |project| %>
+  <% @presenter.detailed_projects.each do |project| %>
     <div class="project" id="<%= project_anchor(project) %>">
       <div class="project_name">
         <%= project_status_icon(project) %>
@@ -7,11 +7,8 @@
       </div>
       <table width="100%">
         <tr>
-          <% project.stages.ordered.each_cons(2) do |ahead, behind| %>
+          <% project.compared_stages.each do |ahead, behind, comparison, severity| %>
             <%= render partial: 'stage', locals: { stage: ahead, fully_released: project.fully_released? } %>
-            <%
-              comparison = project.snapshot&.comparisons&.detect{|c| c.behind_stage_id == behind.id && c.ahead_stage_id == ahead.id }
-            %>
             <td class="project_comparison" data-unknown="<%= comparison.nil? %>" data-released="<%= comparison&.released? %>">
               <% if comparison && !comparison.released? %>
                 <ul>
@@ -22,7 +19,7 @@
               <% end %>
             </td>
           <% end %>
-          <%= render partial: 'stage', locals: { stage: project.stages.ordered.last, fully_released: project.fully_released? } %>
+          <%= render partial: 'stage', locals: { stage: project.ordered_stages.last, fully_released: project.fully_released? } %>
         </tr>
       </table>
     </div>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,2 +1,2 @@
 <%= hidden_field_tag 'organization_subscription_identifier', ProjectChannel.organization_identifier(params[:organization_id]) %>
-<%= render partial: "index_#{@view}" %>
+<%= render partial: "index_#{@presenter.view}" %>


### PR DESCRIPTION
## Problem

The `projects#index` action is responsible for rendering both the detailed and dashboard views. It was already somewhat complicated, with some shared logic for sourcing relevant projects and lots of data-massaging and computation happening inline in the views. The recent work in https://github.com/artsy/horizon/pull/35 introduces a more sophisticated calculation of how badly a project needs a deploy, and it would be best for the views to use that same logic for rendering projects (e.g. "red"), but this would introduce even more complexity.

## Solution

Introduce a presenter class that can encapsulate some of the shared logic and provide dead-simple methods for the views to call. It can be tested more straightforwardly and can memo-ize expensive computations. An embedded wrapper class for bare `Project` models helps keeps logic out of the model classes. Once refactored, it's easy to call the existing `ComparisonService.severity_score` [that's used to decide when to auto-deploy] and make it available to the views for each project.