### PR TITLE
Assign appropriate user to release PRs

### DIFF
--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -10,15 +10,24 @@ class DeployService
     access_token = deploy_strategy.profile&.basic_password
     raise 'A profile and basic_password are required for Github authentication' if access_token.blank?
 
+    repo = deploy_strategy.github_repo
     client = Octokit::Client.new(access_token: access_token)
     begin
-      res = client.create_pull_request(
-        deploy_strategy.github_repo,
+      pr = client.create_pull_request(
+        repo,
         deploy_strategy.arguments['base'],
         deploy_strategy.arguments['head'],
         'Deploy',
         'This is an automatically generated release PR!'
       )
+
+      # assign appropriate github user
+      sorted_logins = client.pull_request_commits(repo, pr.number).
+        flat_map{|c| [c.author, c.committer] }.
+        reject{|c| c.type == 'Bot' || c.login == 'web-flow' || c.login[/\bbot\b/] }.
+        group_by(&:login).map{|k,v| [v.size, k] }.sort.reverse.map(&:last)
+      assignee = sorted_logins.detect { |l| client.check_assignee(repo, l) }
+      client.add_assignees(repo, pr.number, assignee) if assignee
     rescue Octokit::UnprocessableEntity
       # PR already exists
     end    

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -13,6 +13,16 @@ RSpec.feature "Deploys", type: :feature do
       profile: profile
     )
   end
+  let(:renovate) { double('user', type: 'Bot', login: 'renovate') }
+  let(:joe) { double('user', type: 'User', login: 'joe') }
+  let(:jane) { double('user', type: 'User', login: 'jane') }
+  let(:web_flow) { double('user', type: 'User', login: 'web-flow') }
+  let(:commits) do
+    [
+      double('commit', author: renovate, committer: renovate),
+      double('commit', author)
+    ]
+  end
 
   it "raises error unless profile.basic_password is present" do
     invalid_strategy = stages.last.deploy_strategies.create!(
@@ -25,8 +35,28 @@ RSpec.feature "Deploys", type: :feature do
     }.to raise_error('A profile and basic_password are required for Github authentication')
   end
 
-  it "Sends an Octokit request to create pull request when initializing a client" do
-    expect_any_instance_of(Octokit::Client).to receive(:create_pull_request)
+  it "sends an Octokit request to create pull request when initializing a client" do
+    expect_any_instance_of(Octokit::Client).to receive(:create_pull_request).
+      with('artsy/candela', 'release', 'staging', anything, anything).
+      and_return(double(number: 42))
+    allow_any_instance_of(Octokit::Client).to receive(:pull_request_commits).and_return([])
+    DeployService.start(strategy)
+  end
+
+  it 'assigns deploy pull request to appropriate user' do
+    expect_any_instance_of(Octokit::Client).to receive(:create_pull_request).
+      with('artsy/candela', 'release', 'staging', anything, anything).
+      and_return(double(number: 42))
+    allow_any_instance_of(Octokit::Client).to receive(:pull_request_commits).
+      with('artsy/candela', 42).
+      and_return([
+        double(author: renovate, committer: renovate),
+        double(author: joe, committer: jane),
+        double(author: jane, committer: web_flow),
+        double(author: renovate, committer: jane)
+      ])
+    expect_any_instance_of(Octokit::Client).to receive(:check_assignee).and_return(true)
+    expect_any_instance_of(Octokit::Client).to receive(:add_assignees).with('artsy/candela', 42, 'jane')
     DeployService.start(strategy)
   end
 end


### PR DESCRIPTION
After creating a new release PR, this loads the associated commits and attempts to identify the most natural assignee. It considers `author`s and `committer`s (since they can be different) and tries to exclude bots, users suspected of being bots, and the special [web-flow](https://github.com/web-flow) github user.

(Not much to it!)