### PR TITLE
Respect blocks when automatically starting deploys

### DIFF
--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -54,9 +54,11 @@ class ComparisonService
       new_snapshot = store_new_snapshot!(project, result, refreshed_at)
       clean_up_old_snapshots
     end
-    project.stages.select { |s| warrants_deploy?(s) }.each do |stage|
-      stage.deploy_strategies.each do |strategy|
-        DeployService.start(strategy) if strategy.automatic?
+    unless project.deploy_blocks.unresolved.any?
+      project.stages.select { |s| warrants_deploy?(s) }.each do |stage|
+        stage.deploy_strategies.each do |strategy|
+          DeployService.start(strategy) if strategy.automatic?
+        end
       end
     end
     new_snapshot

--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -54,7 +54,7 @@ class ComparisonService
       new_snapshot = store_new_snapshot!(project, result, refreshed_at)
       clean_up_old_snapshots
     end
-    unless project.deploy_blocks.unresolved.any?
+    if project.deploy_blocks.unresolved.empty?
       project.stages.select { |s| warrants_deploy?(s) }.each do |stage|
         stage.deploy_strategies.each do |strategy|
           DeployService.start(strategy) if strategy.automatic?

--- a/spec/features/comparisons_spec.rb
+++ b/spec/features/comparisons_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.feature "Comparisons", type: :feature do
+  let(:org) { Organization.create! name: 'Artsy' }
+  let(:profile) { org.profiles.create!(basic_password: 'foo') }
+  let(:project) do
+    org.projects.create!(name: 'shipping').tap do |p|
+      p.stages.create!(name: 'master')
+      p.stages.create!(name: 'production')
+    end
+  end
+  let(:small_comparison) do
+    double('Releasecop::Comparison',
+      ahead: double('Releasecop::ManifestItem', name: 'master'),
+      behind: double('Releasecop::ManifestItem', name: 'production'),
+      :unreleased? => true,
+      lines: ['commit foo', 'commit bar']
+    )
+  end
+  let(:large_comparison) do
+    double('Releasecop::Comparison',
+      ahead: double('Releasecop::ManifestItem', name: 'master'),
+      behind: double('Releasecop::ManifestItem', name: 'production'),
+      :unreleased? => true,
+      lines: (0..20).map { |i| "commit #{i}" }
+    )
+  end
+
+  it 'cleans up old snapshots' do
+    snapshots = 5.times.map do |i|
+      project.snapshots.create!(refreshed_at: Time.now + i.days).tap do |snapshot|
+        snapshot.comparisons.create!(
+          ahead_stage: project.stages.first,
+          behind_stage: project.stages.last,
+          released: false,
+          description: [i])
+      end
+    end
+    expect(project.snapshots.size).to eq(5)
+    allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
+      Releasecop::Result.new('shipping', [small_comparison])
+    )
+    ComparisonService.new(project).refresh_comparisons
+    expect(project.snapshots.size).to eq(5)
+    expect(Snapshot.where(id: snapshots.first.id).count).to eq(0)
+  end
+
+  context 'deploys' do
+    it 'deploys when warranted and automatic' do
+      project.stages.last.deploy_strategies.create!(
+        provider: 'github pull request',
+        profile: profile,
+        automatic: true,
+        arguments: { base: 'release', head: 'staging ' }
+      )
+      allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
+        Releasecop::Result.new('shipping', [large_comparison])
+      )
+      expect(DeployService).to receive(:start)
+      ComparisonService.new(project).refresh_comparisons
+    end
+
+    it 'does nothing unless warranted' do
+      project.stages.last.deploy_strategies.create!(
+        provider: 'github pull request',
+        profile: profile,
+        automatic: true,
+        arguments: { base: 'release', head: 'staging ' }
+      )
+      allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
+        Releasecop::Result.new('shipping', [small_comparison])
+      )
+      expect(DeployService).not_to receive(:start)
+      ComparisonService.new(project).refresh_comparisons
+    end
+
+    it 'does nothing when deploy warranted but automatic is false' do
+      project.stages.last.deploy_strategies.create!(
+        provider: 'github pull request',
+        profile: profile,
+        automatic: false,
+        arguments: { base: 'release', head: 'staging ' }
+      )
+      allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
+        Releasecop::Result.new('shipping', [large_comparison])
+      )
+      expect(DeployService).not_to receive(:start)
+      ComparisonService.new(project).refresh_comparisons
+    end
+
+    it 'does nothing when the project has unresolved deploy blocks' do
+      project.stages.last.deploy_strategies.create!(
+        provider: 'github pull request',
+        profile: profile,
+        automatic: true,
+        arguments: { base: 'release', head: 'staging ' }
+      )
+      allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
+        Releasecop::Result.new('shipping', [large_comparison])
+      )
+      project.deploy_blocks.create!(description: 'staging broken')
+      expect(DeployService).not_to receive(:start)
+      ComparisonService.new(project).refresh_comparisons
+    end
+  end
+end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Deploys", type: :feature do
     }.to raise_error('A profile and basic_password are required for Github authentication')
   end
 
-  it "sends an Octokit request to create pull request when initializing a client" do
+  it "sends an Octokit request to create pull request" do
     expect_any_instance_of(Octokit::Client).to receive(:create_pull_request).
       with('artsy/candela', 'release', 'staging', anything, anything).
       and_return(double(number: 42))

--- a/spec/features/organizations_spec.rb
+++ b/spec/features/organizations_spec.rb
@@ -10,14 +10,6 @@ RSpec.feature "Organizations", type: :feature do
       lines: ['commit foo', 'commit bar']
     )
   end
-  let(:large_comparison) do
-    double('Releasecop::Comparison',
-      ahead: double('Releasecop::ManifestItem', name: 'master'),
-      behind: double('Releasecop::ManifestItem', name: 'production'),
-      :unreleased? => true,
-      lines: (0..20).map { |i| "commit #{i}" }
-    )
-  end
 
   scenario 'view organizations and projects' do
     project = org.projects.create!(name: 'shipping')
@@ -47,99 +39,5 @@ RSpec.feature "Organizations", type: :feature do
     expect {
       ComparisonService.new(project).refresh_comparisons
     }.not_to change(Snapshot, :count)
-  end
-
-
-  it 'cleans up old snapshots' do
-    project = org.projects.create!(name: 'shipping')
-    ahead = project.stages.create!(name: 'master')
-    behind = project.stages.create!(name: 'production')
-    snapshots = 5.times.map do |i|
-      project.snapshots.create!(refreshed_at: Time.now + i.days).tap do |snapshot|
-        snapshot.comparisons.create!(ahead_stage: ahead, behind_stage: behind, released: false, description: [i])
-      end
-    end
-    expect(project.snapshots.size).to eq(5)
-    allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
-      Releasecop::Result.new('shipping', [releasecop_comparison])
-    )
-    ComparisonService.new(project).refresh_comparisons
-    expect(project.snapshots.size).to eq(5)
-    expect(Snapshot.where(id: snapshots.first.id).count).to eq(0)
-  end
-
-  context 'deploys' do
-    it 'deploys when warranted and automatic' do
-      project = org.projects.create!(name: 'shipping')
-      project.stages.create!(name: 'master')
-      prod = project.stages.create!(name: 'production')
-      profile = org.profiles.create!(basic_password: 'foo')
-      prod.deploy_strategies.create!(
-        provider: 'github pull request',
-        profile: profile,
-        automatic: true,
-        arguments: { base: 'release', head: 'staging ' }
-      )
-      allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
-        Releasecop::Result.new('shipping', [large_comparison])
-      )
-      expect(DeployService).to receive(:start)
-      ComparisonService.new(project).refresh_comparisons
-    end
-
-    it 'does nothing unless warranted' do
-      project = org.projects.create!(name: 'shipping')
-      project.stages.create!(name: 'master')
-     prod = project.stages.create!(name: 'production')
-      profile = org.profiles.create!(basic_password: 'foo')
-      prod.deploy_strategies.create!(
-        provider: 'github pull request',
-        profile: profile,
-        automatic: true,
-        arguments: { base: 'release', head: 'staging ' }
-      )
-      allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
-        Releasecop::Result.new('shipping', [releasecop_comparison])
-      )
-      expect(DeployService).not_to receive(:start)
-      ComparisonService.new(project).refresh_comparisons
-    end
-
-    it 'does nothing when deploy warranted but automatic is false' do
-      project = org.projects.create!(name: 'shipping')
-      project.stages.create!(name: 'master')
-      prod = project.stages.create!(name: 'production')
-      profile = org.profiles.create!(basic_password: 'foo')
-      prod.deploy_strategies.create!(
-        provider: 'github pull request',
-        profile: profile,
-        automatic: false,
-        arguments: { base: 'release', head: 'staging ' }
-      )
-      allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
-        Releasecop::Result.new('shipping', [large_comparison])
-      )
-      expect(DeployService).not_to receive(:start)
-      ComparisonService.new(project).refresh_comparisons
-    end
-
-    it 'respects deploy blocks' do
-      project = org.projects.create!(name: 'shipping')
-      project.stages.create!(name: 'master')
-      prod = project.stages.create!(name: 'production')
-      profile = org.profiles.create!(basic_password: 'foo')
-      prod.deploy_strategies.create!(
-        provider: 'github pull request',
-        profile: profile,
-        automatic: true,
-        arguments: { base: 'release', head: 'staging ' }
-      )
-      allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
-        Releasecop::Result.new('shipping', [large_comparison])
-      )
-      project.deploy_blocks.create!(description: 'staging broken')
-      expect(DeployService).not_to receive(:start)
-      ComparisonService.new(project).refresh_comparisons
-    end
   end
 end


### PR DESCRIPTION
Our new concept of deploy strategies should respect our new concept of deploy blocks.