### PR TITLE
Display when a project's deploys are blocked

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -20,6 +20,9 @@
 
   div.project .project_name {
     font-weight: bold;
+    div.blocked {
+      display: inline;
+    }
   }
   div.project .project_name a {
     color: currentColor;
@@ -119,6 +122,10 @@
     margin: 30px;
     margin-top: 0;
     float: left;
+
+    .blocked {
+      float: right;
+    }
   }
 
   .todo .project.red {

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -55,4 +55,10 @@ module ProjectsHelper
     else 'red'
     end
   end
+
+  def blocked(project)
+    blocks = project.deploy_blocks.unresolved.to_a
+    return if blocks.empty?
+    tag.div(raw('&#9888;'), class: 'blocked', title: blocks.map(&:description).to_sentence)
+  end
 end

--- a/app/presenters/projects_presenter.rb
+++ b/app/presenters/projects_presenter.rb
@@ -23,7 +23,7 @@ class ProjectsPresenter
 
   class ProjectWrapper
     attr_accessor :project
-    delegate :name, :snapshot, :id, :description, to: :project
+    delegate :name, :snapshot, :id, :description, :deploy_blocks, to: :project
 
     def initialize(project)
       @project = project

--- a/app/views/projects/_index_dashboard.html.erb
+++ b/app/views/projects/_index_dashboard.html.erb
@@ -4,7 +4,10 @@
   <div class="todo">
     <% @presenter.unreleased_projects.each do |project| %>
       <div class="project <%= healthy_count_class(project.severity) %>">
-        <h2><%= project.name.titleize %></h2>
+        <h2>
+          <%= project.name.titleize %>
+          <%= blocked(project) %>
+        </h2>
         <p><%= project.description %></p>
         <div class="error_message"><%= project.snapshot&.error_message %></div>
         <div class="comparisons">

--- a/app/views/projects/_index_detail.html.erb
+++ b/app/views/projects/_index_detail.html.erb
@@ -4,6 +4,7 @@
       <div class="project_name">
         <%= project_status_icon(project) %>
         <%= link_to project.name, { anchor: project_anchor(project) }, 'data-turbolinks' => false %>
+        <%= blocked(project) %>
       </div>
       <table width="100%">
         <tr>


### PR DESCRIPTION
`DeployBlock`s were added in https://github.com/artsy/horizon/pull/32. This adds a visual indicator to the dashboard when a project's deploys are blocked. Hovering on the blocked symbol shows the block description(s).

Looks like:

![](https://cl.ly/70cec76bf000/Screen%20Shot%202019-08-16%20at%203.50.43%20PM.png)