### PR TITLE
Manage deploy blockers in active admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'acts_as_list' # order Project#stages
 gem 'releasecop', '>= 0.0.15' # compare release stages
 gem 'activeadmin' # manage models
+gem 'active_admin_datetimepicker'
 gem 'redis' # actioncable adapter
 gem "octokit", "~> 4.0" # talk to github api
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,10 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_admin_datetimepicker (0.7.2)
+      activeadmin (>= 1.1, < 3.a)
+      coffee-rails
+      xdan-datetimepicker-rails (~> 2.5.4)
     activeadmin (1.3.1)
       arbre (>= 1.1.1)
       coffee-rails
@@ -245,6 +249,9 @@ GEM
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
+    xdan-datetimepicker-rails (2.5.4)
+      jquery-rails
+      rails (>= 3.2.16)
     xpath (3.1.0)
       nokogiri (~> 1.8)
 
@@ -252,6 +259,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_admin_datetimepicker
   activeadmin
   acts_as_list
   byebug

--- a/app/admin/deploy_blocks.rb
+++ b/app/admin/deploy_blocks.rb
@@ -1,4 +1,20 @@
 ActiveAdmin.register DeployBlock do
-  belongs_to :project
-  permit_params :description, :resolved_at
+  actions :all, except: [:destroy]
+
+  permit_params :resolved_at, :description, :project_id
+
+  form do |f|
+    semantic_errors
+    inputs do
+      input :project
+      input(
+        :resolved_at,
+        as: :date_time_picker,
+        datepicker_options: { formatTime: 'g:ia' },
+        label: "Resolved At (TZ: Eastern Time)"
+      )
+      input :description
+    end
+    actions
+  end
 end

--- a/app/assets/javascripts/active_admin.js.coffee
+++ b/app/assets/javascripts/active_admin.js.coffee
@@ -1,1 +1,2 @@
 #= require active_admin/base
+#= require active_admin_datetimepicker

--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -10,6 +10,7 @@
 // Active Admin's got SASS!
 @import "active_admin/mixins";
 @import "active_admin/base";
+@import "active_admin_datetimepicker";
 
 // Overriding any non-variable SASS must be done after the fact.
 // For example, to change the default status-tag color:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,4 +3,10 @@ class ApplicationController < ActionController::Base
     name: Horizon.config[:basic_auth_user],
     password: Horizon.config[:basic_auth_pass]
   ) if Horizon.config[:basic_auth_pass].present?
+
+  private
+
+  def set_admin_timezone
+    Time.zone = 'Eastern Time (US & Canada)'
+  end
 end

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -154,6 +154,7 @@ ActiveAdmin.setup do |config|
   # https://github.com/svenfuchs/i18n/blob/master/lib%2Fi18n%2Fbackend%2Fbase.rb#L52
   #
   config.localize_format = :long
+  config.before_action :set_admin_timezone
 
   # == Setting a Favicon
   #


### PR DESCRIPTION
* Use active_admin_datetimepicker gem to get nice selection UI
* Set timezone to be EDT when in active admin

![create-deploy-block](https://user-images.githubusercontent.com/1561546/63291466-96f20280-c291-11e9-98a6-86e9a75274fb.gif)
