### PR TITLE
Fix link helper and add test that renders a few admin views

### DIFF
--- a/app/admin/projects.rb
+++ b/app/admin/projects.rb
@@ -14,7 +14,7 @@ ActiveAdmin.register Project do
   sidebar 'Associated Data', only: %i[show edit] do
     ul do
       li link_to 'Stages', admin_project_stages_path(project)
-      li link_to 'Deploy Blocks', admin_project_deploy_blocks_path(project)
+      li link_to 'Deploy Blocks', admin_deploy_blocks_path(q: { project_id_eq: project.id })
     end
   end
 

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.feature "Administration", type: :feature do
+  scenario 'sets up org and project' do
+    visit '/admin'
+    expect(page).to have_content('Horizon')
+
+    click_link 'Organizations'
+    expect(page).to have_content('There are no Organizations')
+
+    click_link 'New Organization'
+    fill_in 'Name', with: 'Etsy'
+    click_button 'Create Organization'
+    expect(page).to have_content('Etsy')
+
+    click_link 'Projects'
+    expect(page).to have_content('There are no Projects')
+
+    click_link 'New Project'
+    select 'Etsy', from: 'Organization'
+    fill_in 'Name', with: 'Shipping'
+    click_button 'Create Project'
+    expect(page).to have_content('Shipping')
+  end
+end


### PR DESCRIPTION
This fixes a link helper call.

It might be controversial to test activeadmin views but at this point we've mistakenly broken those views a few time so I thought at least a lightweight test was warranted. 