### PR TITLE
Show deploy blocks on projects without releases

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -226,6 +226,10 @@
     padding: 0;
     margin: 0;
     margin-top: -4px;
+
+    .blocked {
+      float: right;
+    }
   }
 
   .released-project p {

--- a/app/views/projects/_index_dashboard.html.erb
+++ b/app/views/projects/_index_dashboard.html.erb
@@ -46,7 +46,11 @@
   <div class="released">
     <% @presenter.released_projects.each do |project| %>
       <div class="released-project">
-      <h2><div class="circle green"></div><%= project.name.titleize %></h2>
+      <h2>
+        <div class="circle green"></div>
+        <%= project.name.titleize %>
+        <%= blocked(project) %>
+      </h2>
       <p><%= project.description %></p>
       </div>
     <% end %>


### PR DESCRIPTION
This essentially just makes blocks visible on projects that aren't in need of a release

<img width="323" alt="image" src="https://user-images.githubusercontent.com/3087225/63608220-7207d300-c5a2-11e9-823e-b55bbb4bc067.png">
