### PR TITLE
Broadcast over websockets when deploy blocks change

### DIFF
--- a/app/assets/javascripts/channels/project.coffee.erb
+++ b/app/assets/javascripts/channels/project.coffee.erb
@@ -11,5 +11,5 @@ $(->
 
     received: (data) ->
       # Called when there's incoming data on the websocket for this channel
-      location.reload() if data.newSnapshots?
+      location.reload() if data.newSnapshots? || data.updatedBlocks?
 )

--- a/app/models/deploy_block.rb
+++ b/app/models/deploy_block.rb
@@ -3,4 +3,14 @@ class DeployBlock < ApplicationRecord
 
   scope :unresolved, -> { where(resolved_at: nil) }
   scope :resolved, -> { where.not(resolved_at: nil) }
+
+  after_save :broadcast_updates
+
+  private
+
+  def broadcast_updates
+    return unless id_previously_changed? || resolved_at_previously_changed?
+    ActionCable.server.broadcast(ProjectChannel.channel_name(project.organization_id), updatedBlocks: true)
+    ActionCable.server.broadcast(ProjectChannel.channel_name, updatedBlocks: true)
+  end
 end

--- a/spec/models/deploy_block_spec.rb
+++ b/spec/models/deploy_block_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe DeployBlock, type: :model do
+  let(:org) { Organization.create!(name: 'artsy') }
+  let(:project) { org.projects.create!(name: 'candela') }
+
+  describe 'websocket broadcasts' do
+    it 'broadcasts on creation' do
+      expect(ActionCable.server).to receive(:broadcast).with("organization:#{org.id}", updatedBlocks: true)
+      expect(ActionCable.server).to receive(:broadcast).with("organization:-1", updatedBlocks: true)
+      project.deploy_blocks.create!(description: 'broken')
+    end
+
+    it 'broadcasts on resolution' do
+      block = project.deploy_blocks.create!(description: 'broken')
+      expect(ActionCable.server).to receive(:broadcast).with("organization:#{org.id}", updatedBlocks: true)
+      expect(ActionCable.server).to receive(:broadcast).with("organization:-1", updatedBlocks: true)
+      block.update!(resolved_at: Time.now)
+    end
+
+    it 'does nothing upon uninteresting updates' do
+      block = project.deploy_blocks.create!(description: 'broken', resolved_at: Time.now)
+      expect(ActionCable.server).not_to receive(:broadcast)
+      block.update!(description: 'not broken anymore')
+    end
+  end
+end


### PR DESCRIPTION
I noticed that dashboards don't necessarily refresh when deploy blocks change. This fixes that.