### PR TITLE
Make blocker warning more distinct

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -71,7 +71,8 @@
   .project_status_unknown {
     color: #999;
   }
-  .project_status_warning, .project_status_error {
+  .project_status_warning,
+  .project_status_error {
     color: #900;
   }
 }
@@ -114,7 +115,7 @@
   }
 
   .todo .project {
-    border: 1px solid #E5E5E5;
+    border: 1px solid #e5e5e5;
     border-radius: 2px;
     padding: 16px;
     width: calc(286px - 32px);
@@ -124,12 +125,13 @@
     float: left;
 
     .blocked {
+      user-select: none;
       float: right;
     }
   }
 
   .todo .project.red {
-    border: 1px solid #F7625A;
+    border: 1px solid #f7625a;
   }
 
   .todo .project h2 {
@@ -142,7 +144,7 @@
     margin-bottom: 0px;
     margin-right: 16px;
     min-height: 40px;
-    background: image-url('arrow.svg') 0.5px 20px no-repeat;
+    background: image-url("arrow.svg") 0.5px 20px no-repeat;
     height: 91px;
     padding-left: 1px;
   }
@@ -190,25 +192,25 @@
     width: 10px;
     height: 10px;
     margin-bottom: 3px;
-    background-color: #0FDB82;
+    background-color: #0fdb82;
     display: inline-block;
     margin-right: 16px;
   }
 
   .comparison.green .circle {
-    background-color: #0FDB82;
+    background-color: #0fdb82;
   }
 
   .comparison.yellow .circle {
-    background-color: #F1AF1B;
+    background-color: #f1af1b;
   }
 
   .comparison.red .circle {
-    background-color: #F7625A;
+    background-color: #f7625a;
   }
 
   .released-project {
-    border: 1px solid #E5E5E5;
+    border: 1px solid #e5e5e5;
     padding: 16px;
     width: calc(286px - 32px);
     height: calc(75px - 32px);
@@ -228,6 +230,7 @@
     margin-top: -4px;
 
     .blocked {
+      user-select: none;
       float: right;
     }
   }

--- a/app/helpers/projects_helper.rb
+++ b/app/helpers/projects_helper.rb
@@ -59,6 +59,6 @@ module ProjectsHelper
   def blocked(project)
     blocks = project.deploy_blocks.unresolved.to_a
     return if blocks.empty?
-    tag.div(raw('&#9888;'), class: 'blocked', title: blocks.map(&:description).to_sentence)
+    tag.div(raw('⚠️'), class: 'blocked', title: blocks.map(&:description).to_sentence)
   end
 end


### PR DESCRIPTION
This is a minor update that just adds some visual distinctness to the blocker notification. Also, I noticed that when you hovered over the blocker icon the cursor changed to a text selection which was a bit annoying. I made the icon non-selectable so now the cursor doesn't change. 

## Before

<img width="331" alt="image" src="https://user-images.githubusercontent.com/3087225/64541454-e1dec300-d2ef-11e9-8174-c7d8d3b8b239.png">

## After

<img width="324" alt="image" src="https://user-images.githubusercontent.com/3087225/64541440-dab7b500-d2ef-11e9-9fde-065750f680d6.png">
