### PR TITLE
Beef up README with recent design changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,17 @@ Horizon
 Visual representations of release pipelines.
 
 * State: internal usage
-* Staging (only): [releases.artsy.net](https://releases.artsy.net)
+* Staging (only): [releases.artsy.net](https://releases.artsy.net) (admin dashboard: [https://releases.artsy.net/admin](https://releases.artsy.net/admin))
 * GitHub: https://github.com/artsy/horizon
 * Point Team: [Platform](https://artsy.slack.com/messages/product-platform)
-* Deployment: builds of the `master` branch are automatically deployed to staging by CircleCI. There is no production environment.
+* Deployment: builds of the `master` branch are automatically deployed to staging by CircleCI. **There is no production environment.**
 
-Features
+Quick links
 ---
-- [Release Dashboard](https://releases.artsy.net/projects?organization_id=1&view=dashboard)
-- [Release Detail](https://releases.artsy.net/projects?organization_id=1)
-- [Deploy Blockers](https://releases.artsy.net/admin/deploy_blocks)
+- [Releases: dashboard view](https://releases.artsy.net/projects?organization_id=1&view=dashboard)
+- [Releases: detailed view](https://releases.artsy.net/projects?organization_id=1)
+- [View deploy blocks](https://releases.artsy.net/admin/deploy_blocks) or [create a new one](https://releases.artsy.net/admin/deploy_blocks)
+- [View projects](https://releases.artsy.net/admin/projects) or [create a new one](https://releases.artsy.net/admin/projects/new)
 
 Design
 ---
@@ -23,6 +24,8 @@ Design
 * `Stage`s can optionally be associated with a `Profile` that stores credentials for accessing git providers or AWS.
 * `Snapshot`s capture the complete state of a project's stages at a point in time. Each `Snapshot` has associated `Comparison`s between the consecutive stages of a project (e).g., a comparison between _master_ and _staging_, and a second between _staging_ and _production_)
 * A cron periodically reevaluates these comparisons, creating a new snapshot if the state has changed at all.
+* A `Stage` (such as "production") can have a `DeployStrategy` for automatically triggering releases. Currently only the "github pull request" provider is implemented. When defined, a deploy strategy will automatically start a release (e.g., by opening a pull request) when a diff exceeds a certain threshold.
+* `DeployBlock`s indicate that a project _should not_ be released. In addition to appearing on dashboards, any unresolved blocks will prevent new releases from being automated.
 
 Setup
 ---
@@ -74,5 +77,5 @@ TO DO
 * button to refresh project on-demand
 * ~~Fix ugly AWS credentials -> hokusai flow~~
 * ~~Make errors [when refreshing projects] visible and avoid short-circuiting entire cron~~
-* Make sorting and classifying of projects more sophisticated (penalize staleness and number of contributors and not just number of commits)
+* ~~Make sorting and classifying of projects more sophisticated (penalize staleness and number of contributors and not just number of commits)~~
 * ~~Add tags to projects and enable filtering dashboard/list view by them~~


### PR DESCRIPTION
Described the new deploy "strategies" and "blocks" in `README.md`.

Hope it's OK I also renamed the section you added to "quick links" to grab developers' attention.