### PR TITLE
Always open a deploy PR if a service is behind

### DIFF
--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -71,8 +71,7 @@ class ComparisonService
       c.behind_stage == stage
     end
     return false unless comparison
-
-    self.class.comparison_score(comparison) > DEPLOY_AT_SEVERITY
+    return true
   end
 
   def equivalent_snapshots?(snapshot, result)

--- a/spec/features/comparisons_spec.rb
+++ b/spec/features/comparisons_spec.rb
@@ -60,20 +60,6 @@ RSpec.feature "Comparisons", type: :feature do
       ComparisonService.new(project).refresh_comparisons
     end
 
-    it 'does nothing unless warranted' do
-      project.stages.last.deploy_strategies.create!(
-        provider: 'github pull request',
-        profile: profile,
-        automatic: true,
-        arguments: { base: 'release', head: 'staging ' }
-      )
-      allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
-        Releasecop::Result.new('shipping', [small_comparison])
-      )
-      expect(DeployService).not_to receive(:start)
-      ComparisonService.new(project).refresh_comparisons
-    end
-
     it 'does nothing when deploy warranted but automatic is false' do
       project.stages.last.deploy_strategies.create!(
         provider: 'github pull request',


### PR DESCRIPTION
Essentially this removes the severity hurdle for opening a deployment PR. Originally I know the barrier was placed in front of this to reduce the noise created by deployment PRs, but I feel it's beneficial to have them automatically created when available. 

There was a conversation on this slack, but I haven't been able to dig it up. 