### PR TITLE
Give deploy user permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN bundle install -j4
 COPY . ./
 
 # Precompile Rails assets
-RUN bundle exec rake assets:precompile
+RUN bundle exec rake assets:precompile && \
+    chown -R deploy:deploy ./
 
 # Switch to less privelidged user
 USER deploy


### PR DESCRIPTION
Follow up to #73, staging rollout failed because of missing permissions for deploy user. 