### PR TITLE
Add shared directories for puma

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,11 @@ RUN gem install bundler -v '<2' && \
 COPY Gemfile Gemfile.lock .ruby-version ./
 RUN bundle install -j4
 
+
+# Create directories for Puma/Nginx & give deploy user access
+RUN mkdir -p /shared/pids /shared/sockets && \
+    chown -R deploy:deploy /shared
+
 # Copy application code
 COPY . ./
 


### PR DESCRIPTION
Adds shared directories for puma to `Dockerfile`

Latest staging deploy did not go out on puma error:
<img width="697" alt="Screen Shot 2020-06-01 at 1 03 21 PM" src="https://user-images.githubusercontent.com/1497424/83434515-a7323300-a408-11ea-8c22-f4f43f4ad191.png">
