### PR TITLE
Ignore prop-types in ts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,14 @@ module.exports = {
     "plugin:react/recommended",
     "prettier",
   ],
+  overrides: [
+    {
+      files: ["**/*.tsx"],
+      rules: {
+        "react/prop-types": "off",
+      },
+    },
+  ],
   parser: "@typescript-eslint/parser",
   parserOptions: {
     ecmaFeatures: {
@@ -30,7 +38,7 @@ module.exports = {
   },
   settings: {
     react: {
-      version: "detect", 
+      version: "detect",
     },
-  }
+  },
 }


### PR DESCRIPTION
Update to .eslintrc to ignore prop-types expectations (prop-types are not used by typescript).