### PR TITLE
#migration add Ingress resources

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -160,6 +160,48 @@ spec:
     - 104.16.0.0/12
     - 172.64.0.0/13
     - 131.0.72.0/22
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: horizon
+    component: web
+    layer: application
+  name: horizon-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: 8080
+  selector:
+    app: horizon
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: horizon
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/12,172.64.0.0/13,131.0.72.0/22"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+spec:
+  rules:
+    - host: releases.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: horizon-web-internal
+              servicePort: http
+
 ---
 apiVersion: batch/v2alpha1
 kind: CronJob

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -161,14 +161,36 @@ spec:
     - 131.0.72.0/22
 
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: horizon
+    component: web
+    layer: application
+  name: horizon-web-internal
+  namespace: default
+spec:
+  ports:
+    - port: 8080
+      protocol: TCP
+      name: http
+      targetPort: 8080
+  selector:
+    app: horizon
+    layer: application
+    component: web
+  type: ClusterIP
+
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: horizon
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: 173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/12,172.64.0.0/13,131.0.72.0/22
-    nginx.ingress.kubernetes.io/proxy-send-timeout: 3600
-    nginx.ingress.kubernetes.io/proxy-read-timeout: 3600
+    nginx.ingress.kubernetes.io/whitelist-source-range: "173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/12,172.64.0.0/13,131.0.72.0/22"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
 spec:
   rules:
     - host: releases-staging.artsy.net
@@ -176,8 +198,8 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: horizon-web
-              servicePort: horizon-http
+              serviceName: horizon-web-internal
+              servicePort: http
 
 ---
 apiVersion: batch/v2alpha1

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -159,6 +159,26 @@ spec:
     - 104.16.0.0/12
     - 172.64.0.0/13
     - 131.0.72.0/22
+
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: horizon
+  annotations:
+    nginx.ingress.kubernetes.io/whitelist-source-range: 173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/12,172.64.0.0/13,131.0.72.0/22
+    nginx.ingress.kubernetes.io/proxy-send-timeout: 3600
+    nginx.ingress.kubernetes.io/proxy-read-timeout: 3600
+spec:
+  rules:
+    host: releases-staging.artsy.net
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: horizon-web
+              servicePort: horizon-http
+
 ---
 apiVersion: batch/v2alpha1
 kind: CronJob

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -171,7 +171,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: 3600
 spec:
   rules:
-    host: releases-staging.artsy.net
+    - host: releases-staging.artsy.net
       http:
         paths:
           - path: /


### PR DESCRIPTION
Move to Ingress controllers with Websockets configuration.  Checking ingress controller [docs](https://kubernetes.github.io/ingress-nginx/user-guide/miscellaneous/#websockets)

```
Support for websockets is provided by NGINX out of the box. No special configuration required.

The only requirement to avoid the close of connections is the increase of the values of proxy-read-timeout and proxy-send-timeout.

The default value of this settings is 60 seconds.

A more adequate value to support websockets is a value higher than one hour (3600).
```

Also make use of the `whitelist-source-range` [annotation](https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#whitelist-source-range) to restrict traffic to Cloudflare edge IP ranges.

One further consideration is that the NLB's [idle timeout and global nginx ingress keepalive-timeout](https://kubernetes.github.io/ingress-nginx/deploy/#nlb-idle-timeouts) may need to be bumped to 3600 as well.

> An idle timeout of 3600 is recommended when using WebSockets

## Migration

1) Merge this PR and deploy to production to create the Ingress resource and horizon-web-internal service

2) Update DNS for releases.artsy.net to the DNS record for the Ingress controller (check `hokusai production status`)

3) Once traffic is cut over, open a follow-up PR to delete the horizon-web LoadBalancer service

Steps 1 & 2 already applied to staging and tested websockets connection and whitelist-source-range s