### PR TITLE
Only run staging cron once a day

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -165,7 +165,7 @@ kind: CronJob
 metadata:
   name: horizon-refresh-cron
 spec:
-  schedule: "*/10 * * * *"
+  schedule: "0 9 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:


### PR DESCRIPTION
We're hitting the github API too frequently, bumps down staging cron schedule to once a day.
Related conversation:
https://artsy.slack.com/archives/CA8SANW3W/p1592323112167000