### PR TITLE
Refresh data for all orgs in cron

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,10 +13,9 @@ namespace :cron do
   end
 
   task refresh_components: :environment do
-    ProjectDataService.refresh_data_for_org(
-      Organization.find(Horizon.config[:default_org_id]) || Organization.first,
-      Horizon.config[:github_access_token]
-    )
+    Organization.all.each do |org|
+      ProjectDataService.refresh_data_for_org(org)
+    end
   end
 end
 


### PR DESCRIPTION
Follow up to #121, run cron on all projects (forgot to move now non-existent `default_org_id`).