### PR TITLE
fix indentation in production.yml

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -247,8 +247,8 @@ spec:
         spec:
           containers:
             - name: horizon-refresh-components-cron
-            image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/horizon:production
-            args: ["bundle", "exec", "rake", "cron:refresh_components"]
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/horizon:production
+              args: ["bundle", "exec", "rake", "cron:refresh_components"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:


### PR DESCRIPTION
Fix indentation in `horizon-refresh-components-cron` container spec

Deploy / update failed with 
```
error: error converting YAML to JSON: yaml: line 13: did not find expected '-' indicator
Traceback (most recent call last):
  File "hokusai/lib/command.py", line 17, in wrapper
  File "hokusai/commands/kubernetes.py", line 79, in k8s_update
  File "hokusai/lib/common.py", line 78, in shout
  File "subprocess.py", line 186, in check_call
CalledProcessError: Command 'kubectl --context production apply -f /Users/isacpetruzzi/src/artsy/horizon/.hokusai-tmp/production.yml --dry-run' returned non-zero exit status 1
```