### PR TITLE
Development fixes and small release-assignment improvement

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ gem 'semantic'
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
-  gem 'dotenv-rails'
   gem 'rspec-rails' # tests!
   gem 'rubocop', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,10 +99,6 @@ GEM
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     diff-lcs (1.3)
-    dotenv (2.7.5)
-    dotenv-rails (2.7.5)
-      dotenv (= 2.7.5)
-      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     execjs (2.7.0)
     faraday (1.0.1)
@@ -319,7 +315,6 @@ DEPENDENCIES
   acts_as_list
   byebug
   capybara
-  dotenv-rails
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   octokit (~> 4.0)

--- a/README.md
+++ b/README.md
@@ -18,12 +18,16 @@ Visual representations of release pipelines.
 
 ## Setup
 
-    # via hokusai
+With docker:
+
     hokusai dev run 'bundle exec rake db:migrate'
     hokusai dev start
-    # or
-    dotenv bundle exec rails db:prepare
-    dotenv bundle exec rails server
+
+Or on localhost:
+
+    bundle exec rails db:prepare
+    yarn install
+    bundle exec rails server
 
     # run the webpack-dev-server in a seperate terminal window for hot reloading:
     ./bin/webpack-dev-server

--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -59,7 +59,7 @@ class ComparisonService
     if project.deploy_blocks.unresolved.empty?
       project.stages.select { |s| warrants_deploy?(s) }.each do |stage|
         stage.deploy_strategies.each do |strategy|
-          DeployService.start(strategy) if strategy.automatic?
+          DeployService.new(strategy).start if strategy.automatic?
         end
       end
     end

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -28,7 +28,16 @@ class DeployService
     assignee = choose_assignee(pull_request)
     github_client.add_assignees(github_repo, pull_request.number, assignee) if assignee
   rescue Octokit::UnprocessableEntity
-    # PR already exists
+    # PR already exists, so assign if unassigned
+    pull_request = github_client.pull_requests(
+      github_repo,
+      base: deploy_strategy.arguments['base'],
+      head: deploy_strategy.arguments['head']
+    ).first
+    if pull_request && pull_request.assignee.blank?
+      assignee = choose_assignee(pull_request)
+      github_client.add_assignees(github_repo, pull_request.number, assignee) if assignee
+    end
   end
 
   def github_client

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -1,37 +1,56 @@
 # frozen_string_literal: true
 
 class DeployService
-  def self.start(deploy_strategy)
+  attr_accessor :deploy_strategy
+
+  def initialize(deploy_strategy)
+    self.deploy_strategy = deploy_strategy
+  end
+
+  def start
     case deploy_strategy.provider
-    when 'github pull request' then create_github_pull_request(deploy_strategy)
+    when 'github pull request' then create_github_pull_request
     else raise NotImplementedError
     end
   end
 
-  def self.create_github_pull_request(deploy_strategy)
-    access_token = deploy_strategy.profile&.basic_password
-    raise 'A profile and basic_password are required for Github authentication' if access_token.blank?
+  private
 
-    repo = deploy_strategy.github_repo
-    client = Octokit::Client.new(access_token: access_token)
-    begin
-      pr = client.create_pull_request(
-        repo,
-        deploy_strategy.arguments['base'],
-        deploy_strategy.arguments['head'],
-        'Deploy',
-        'This is an automatically generated release PR!'
-      )
+  def create_github_pull_request
+    pull_request = github_client.create_pull_request(
+      github_repo,
+      deploy_strategy.arguments['base'],
+      deploy_strategy.arguments['head'],
+      'Deploy',
+      'This is an automatically generated release PR!'
+    )
 
-      # assign appropriate github user
-      sorted_logins = client.pull_request_commits(repo, pr.number)
-                            .flat_map { |c| [c.author, c.committer] }
-                            .reject { |c| c.type == 'Bot' || c.login == 'web-flow' || c.login[/\bbot\b/] }
-                            .group_by(&:login).map { |k, v| [v.size, k] }.sort.reverse.map(&:last)
-      assignee = sorted_logins.detect { |l| client.check_assignee(repo, l) }
-      client.add_assignees(repo, pr.number, assignee) if assignee
-    rescue Octokit::UnprocessableEntity
-      # PR already exists
-    end
+    assignee = choose_assignee(pull_request)
+    github_client.add_assignees(github_repo, pull_request.number, assignee) if assignee
+  rescue Octokit::UnprocessableEntity
+    # PR already exists
+  end
+
+  def github_client
+    @github_client ||= Octokit::Client.new(access_token: github_access_token)
+  end
+
+  def github_repo
+    @github_repo ||= deploy_strategy.github_repo
+  end
+
+  def github_access_token
+    @github_access_token ||=
+      deploy_strategy.profile&.basic_password.presence ||
+      (raise 'A profile and basic_password are required for Github authentication')
+  end
+
+  def choose_assignee(pull_request)
+    github_client
+      .pull_request_commits(github_repo, pull_request.number)
+      .flat_map { |c| [c.author, c.committer] }
+      .reject { |c| c.type == 'Bot' || c.login == 'web-flow' || c.login[/\bbot\b/] }
+      .group_by(&:login).map { |k, v| [v.size, k] }.sort.reverse.map(&:last)
+      .detect { |l| github_client.check_assignee(github_repo, l) }
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,6 +20,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
+    config.public_file_server.enabled = true
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 2020_07_13_215815) do
     t.string "ci_provider"
     t.boolean "renovate"
     t.string "orbs", default: [], array: true
-    t.integer "criticality", default: 1
+    t.integer "criticality"
     t.index ["organization_id"], name: "index_projects_on_organization_id"
     t.index ["snapshot_id"], name: "index_projects_on_snapshot_id"
   end

--- a/spec/features/comparisons_spec.rb
+++ b/spec/features/comparisons_spec.rb
@@ -57,7 +57,7 @@ RSpec.feature 'Comparisons', type: :feature do
       allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
         Releasecop::Result.new('shipping', [large_comparison])
       )
-      expect(DeployService).to receive(:start)
+      expect_any_instance_of(DeployService).to receive(:start)
       ComparisonService.new(project).refresh_comparisons
     end
 
@@ -71,7 +71,7 @@ RSpec.feature 'Comparisons', type: :feature do
       allow_any_instance_of(Releasecop::Checker).to receive(:check).and_return(
         Releasecop::Result.new('shipping', [large_comparison])
       )
-      expect(DeployService).not_to receive(:start)
+      expect_any_instance_of(DeployService).not_to receive(:start)
       ComparisonService.new(project).refresh_comparisons
     end
 
@@ -86,7 +86,7 @@ RSpec.feature 'Comparisons', type: :feature do
         Releasecop::Result.new('shipping', [large_comparison])
       )
       project.deploy_blocks.create!(description: 'staging broken')
-      expect(DeployService).not_to receive(:start)
+      expect_any_instance_of(DeployService).not_to receive(:start)
       ComparisonService.new(project).refresh_comparisons
     end
   end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -68,4 +68,25 @@ RSpec.feature 'Deploys', type: :feature do
     expect_any_instance_of(Octokit::Client).to receive(:add_assignees).with('artsy/candela', 42, 'jane')
     DeployService.new(strategy).start
   end
+
+  it 'adds assignees to existing deploy PRs when unassigned' do
+    expect_any_instance_of(Octokit::Client).to receive(:create_pull_request)
+      .with('artsy/candela', 'release', 'staging', anything, anything)
+      .and_raise(Octokit::UnprocessableEntity)
+    allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
+      .with('artsy/candela', base: 'release', head: 'staging')
+      .and_return([double(number: 42, assignee: nil)])
+    allow_any_instance_of(Octokit::Client).to receive(:pull_request_commits)
+      .with('artsy/candela', 42)
+      .and_return([
+                    double(author: renovate, committer: renovate),
+                    double(author: joe, committer: jane),
+                    double(author: jane, committer: web_flow),
+                    double(author: renovate, committer: jane)
+                  ])
+    expect_any_instance_of(Octokit::Client).to receive(:check_assignee).and_return(true)
+    expect_any_instance_of(Octokit::Client).to receive(:add_assignees).with('artsy/candela', 42, 'jane')
+
+    DeployService.new(strategy).start
+  end
 end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -40,7 +40,7 @@ RSpec.feature 'Deploys', type: :feature do
       arguments: { base: 'release', head: 'staging' }
     )
     expect do
-      DeployService.start(invalid_strategy)
+      DeployService.new(invalid_strategy).start
     end.to raise_error('A profile and basic_password are required for Github authentication')
   end
 
@@ -49,7 +49,7 @@ RSpec.feature 'Deploys', type: :feature do
       .with('artsy/candela', 'release', 'staging', anything, anything)
       .and_return(double(number: 42))
     allow_any_instance_of(Octokit::Client).to receive(:pull_request_commits).and_return([])
-    DeployService.start(strategy)
+    DeployService.new(strategy).start
   end
 
   it 'assigns deploy pull request to appropriate user' do
@@ -66,6 +66,6 @@ RSpec.feature 'Deploys', type: :feature do
                   ])
     expect_any_instance_of(Octokit::Client).to receive(:check_assignee).and_return(true)
     expect_any_instance_of(Octokit::Client).to receive(:add_assignees).with('artsy/candela', 42, 'jane')
-    DeployService.start(strategy)
+    DeployService.new(strategy).start
   end
 end


### PR DESCRIPTION
Please review by commit, since I had to modify a few things to get this work started. These steps included:
* Some developer environment fixes to be able to run locally.
* Refactored `DeployService` operations into instance methods for better encapsulation and memoization.
* If a release PR already exists, but has no assignee, check if there's a good candidate and assign them.

This^ last problem was my reason for coming here. Often, the initial diff in a release PR is contributed by bots, and human contributors' commits get added later. Until now, Horizon only chose an assignee when creating the release PR (so based only on those initial commits). Going forward, it will add an assignee to an existing release PR when human contributions get added.