### PR TITLE
Use SplitChunksPlugin to move common chunks out

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,7 +7,7 @@
 
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= stylesheet_link_tag 'https://webfonts.artsy.net/unica-webfonts.css' %>
-    <%= javascript_pack_tag 'application' %>
+    <%= javascript_packs_with_chunks_tag 'application' %>
   </head>
 
   <body>

--- a/app/views/projects/index.html.erb
+++ b/app/views/projects/index.html.erb
@@ -1,4 +1,4 @@
 <div id="projects_data" data-props="<%= @props.to_json %>"></div>
 
-<%= javascript_pack_tag 'projects' %>
+<%= javascript_packs_with_chunks_tag 'projects' %>
 <%= hidden_field_tag 'organization_subscription_identifier', ProjectChannel.organization_identifier(params[:organization_id]) %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,3 +1,3 @@
 <div id="project_data" data-props="<%= @props.to_json %>"></div>
 
-<%= javascript_pack_tag 'project' %>
+<%= javascript_packs_with_chunks_tag 'project' %>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,5 @@
 const { environment } = require('@rails/webpacker')
 
+environment.splitChunks()
+
 module.exports = environment


### PR DESCRIPTION
Following https://github.com/artsy/horizon/pull/160, it's clear that we should move common code into a shared chunk, instead of including them in every bundle. This follows the [Webpacker doc](https://github.com/rails/webpacker/blob/v5.1.1/docs/webpack.md#add-splitchunks-webpack-v4) and use [SplitChunksPlugin](https://webpack.js.org/plugins/split-chunks-plugin) to optimize it. This decreases overall JS bundle size. To compare

## Before

![Screen Shot 2020-07-18 at 10 10 00 PM](https://user-images.githubusercontent.com/796573/87866733-26e17600-c953-11ea-9a81-af535594c5cc.png)

## After

![Screen Shot 2020-07-18 at 10 21 50 PM](https://user-images.githubusercontent.com/796573/87866736-2d6fed80-c953-11ea-97b4-1dba7de9c5bb.png)
