### PR TITLE
Remove unnecessary config and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Visual representations of release pipelines.
 
 - [Releases: dashboard view](https://releases.artsy.net/projects?organization_id=1&view=dashboard)
 - [Releases: detailed view](https://releases.artsy.net/projects?organization_id=1)
-- [View deploy blocks](https://releases.artsy.net/admin/deploy_blocks) or [create a new one](https://releases.artsy.net/admin/deploy_blocks)
+- [View deploy blocks](https://releases.artsy.net/admin/deploy_blocks) or [create a new one](https://releases.artsy.net/admin/deploy_blocks/new)
 - [View projects](https://releases.artsy.net/admin/projects) or [create a new one](https://releases.artsy.net/admin/projects/new)
 
 ## Setup
@@ -42,34 +42,36 @@ Artsy developers can use the db setup script to dump our staging data to a local
 
 Alternatively, here's an example using the console:
 
-    org = Organization.create!(name: 'Acme')
-    website = org.projects.create!(name: 'acme.org')
-    heroku = org.profiles.create!(
-      name: 'heroku',
-      basic_username: 'heroku',
-      basic_password: '<heroku_token>'
-    )
-    github_aws = org.profiles.create!(
-      name: 'github/aws',
-      basic_username: 'github',
-      basic_password: '<github_token>',
-      environment: {'AWS_ACCESS_KEY_ID' => '<aws_id>', 'AWS_SECRET_ACCESS_KEY' => '<aws_secret>'}
-    )
-    website.stages.create!(
-      name: 'master',
-      git_remote: 'https://github.com/acme/website.git',
-      profile: github_aws
-    )
-    website.stages.create!(
-      name: 'staging',
-      git_remote: 'https://git.heroku.com/acme-website-staging.git',
-      profile: heroku
-    )
-    website.stages.create!(
-      name: 'production',
-      git_remote: 'https://git.heroku.com/acme-website-production.git',
-      profile: heroku
-    )
+```ruby
+org = Organization.create!(name: 'Acme')
+website = org.projects.create!(name: 'acme.org')
+heroku = org.profiles.create!(
+  name: 'heroku',
+  basic_username: 'heroku',
+  basic_password: '<heroku_token>'
+)
+github_aws = org.profiles.create!(
+  name: 'github/aws',
+  basic_username: 'github',
+  basic_password: '<github_token>',
+  environment: {'AWS_ACCESS_KEY_ID' => '<aws_id>', 'AWS_SECRET_ACCESS_KEY' => '<aws_secret>'}
+)
+website.stages.create!(
+  name: 'master',
+  git_remote: 'https://github.com/acme/website.git',
+  profile: github_aws
+)
+website.stages.create!(
+  name: 'staging',
+  git_remote: 'https://git.heroku.com/acme-website-staging.git',
+  profile: heroku
+)
+website.stages.create!(
+  name: 'production',
+  git_remote: 'https://git.heroku.com/acme-website-production.git',
+  profile: heroku
+)
+```
 
 Once the cron has run, its snapshots are visible from the `/projects` page.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Or on localhost:
     yarn install
     bundle exec rails server
 
-    # run the webpack-dev-server in a seperate terminal window for hot reloading:
+    # run the webpack-dev-server in a seperate terminal window for hot reloading and faster compilation:
     ./bin/webpack-dev-server
 
 The administrative UI can then be found at http://localhost:3000/admin. Create organizations, projects, profiles, and stages from there.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,6 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
 
     config.cache_store = :memory_store
-    config.public_file_server.enabled = true
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{2.days.to_i}"
     }


### PR DESCRIPTION
I think my [suggestion](https://github.com/rails/webpacker/issues/1190#issuecomment-358905190) in c62d7e56978063d264670238e9a4e5190f5855b5 to fix the error below was incorrect.
```
ActionController::RoutingError (No route matches [GET] "/packs/projects-8a758bbeb007e45b4351.js")
```
`config.public_file_server.enabled` is already [by default `true`](https://github.com/rails/rails/blob/v6.0.3/railties/lib/rails/application/configuration.rb#L36) in development. And in fact, the config is wrapped in a condition for [dev caching](https://github.com/artsy/horizon/blob/162420dd4c968e2a83c639b21a112f4b456a0927/config/environments/development.rb#L17-L31) which is also by default disabled. Therefore, I don't think it's making a difference. (The linked issue was for production environment, in which `config.public_file_server.enabled` is set to `false` by default.)

Back to the original problem, I actually can't reproduce it on my local. Either having `webpack-dev-server` running or not, I'm able to compile the assets and load the page. Curious if you can still reproduce it. 🤔 