### PR TITLE
Remove jQuery

### DIFF
--- a/app/javascript/channels/project_channel.ts
+++ b/app/javascript/channels/project_channel.ts
@@ -1,12 +1,14 @@
 import consumer from "./consumer"
 
 document.addEventListener("DOMContentLoaded", () => {
+  const organization_id_input = document.querySelector(
+    "#organization_subscription_identifier",
+  ) as HTMLInputElement
+
   consumer.subscriptions.create(
     {
       channel: "ProjectChannel",
-      organization_id: document.querySelector(
-        "#organization_subscription_identifier",
-      ).value,
+      organization_id: organization_id_input.value,
     },
     {
       connected() {

--- a/app/javascript/channels/project_channel.ts
+++ b/app/javascript/channels/project_channel.ts
@@ -1,10 +1,11 @@
-import $ from "jquery"
 import consumer from "./consumer"
 
 consumer.subscriptions.create(
   {
     channel: "ProjectChannel",
-    organization_id: $("#organization_subscription_identifier").val(),
+    organization_id: document.querySelector(
+      "#organization_subscription_identifier",
+    ).value,
   },
   {
     connected() {

--- a/app/javascript/channels/project_channel.ts
+++ b/app/javascript/channels/project_channel.ts
@@ -1,24 +1,26 @@
 import consumer from "./consumer"
 
-consumer.subscriptions.create(
-  {
-    channel: "ProjectChannel",
-    organization_id: document.querySelector(
-      "#organization_subscription_identifier",
-    ).value,
-  },
-  {
-    connected() {
-      // Called when the subscription is ready for use on the server
+document.addEventListener("DOMContentLoaded", () => {
+  consumer.subscriptions.create(
+    {
+      channel: "ProjectChannel",
+      organization_id: document.querySelector(
+        "#organization_subscription_identifier",
+      ).value,
     },
-    disconnected() {
-      // Called when the subscription has been terminated by the server
+    {
+      connected() {
+        // Called when the subscription is ready for use on the server
+      },
+      disconnected() {
+        // Called when the subscription has been terminated by the server
+      },
+      received(data) {
+        // Called when there's incoming data on the websocket for this channel
+        if (data.newSnapshots || data.updatedBlocks) {
+          location.reload()
+        }
+      },
     },
-    received(data) {
-      // Called when there's incoming data on the websocket for this channel
-      if (data.newSnapshots || data.updatedBlocks) {
-        location.reload()
-      }
-    },
-  },
-)
+  )
+})

--- a/config/webpack/plugins/jquery.js
+++ b/config/webpack/plugins/jquery.js
@@ -1,7 +1,0 @@
-const webpack = require("webpack");
-
-module.exports = new webpack.ProvidePlugin({
-  $: "jquery",
-  jQuery: "jquery",
-  "window.jQuery": "jquery",
-});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@rails/activestorage": "6.0.3-1",
     "@rails/ujs": "6.0.3-1",
     "@rails/webpacker": "5.1.1",
-    "jquery": "3.5.1",
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "styled-components": "4.4.1"
@@ -28,7 +27,6 @@
     "@babel/preset-typescript": "7.10.1",
     "@types/actioncable": "5.2.3",
     "@types/jest": "26.0.0",
-    "@types/jquery": "3.3.38",
     "@types/react": "16.9.35",
     "@types/react-dom": "16.9.8",
     "@types/styled-components": "4.4.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "strict": true,
     "target": "es2016",
     "jsx": "react",
-    "types": ["node", "webpack-env", "jquery", "actioncable", "jest"]
+    "types": ["node", "webpack-env", "actioncable", "jest"]
   },
   "exclude": ["node_modules", "public"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1457,13 +1457,6 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
-"@types/jquery@3.3.38":
-  version "3.3.38"
-  resolved "https://registry.yarnpkg.com/@types/jquery/-/jquery-3.3.38.tgz#6385f1e1b30bd2bff55ae8ee75ea42a999cc3608"
-  integrity sha512-nkDvmx7x/6kDM5guu/YpXkGZ/Xj/IwGiLDdKM99YA5Vag7pjGyTJ8BNUh/6hxEn/sEu5DKtyRgnONJ7EmOoKrA==
-  dependencies:
-    "@types/sizzle" "*"
-
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
@@ -1525,11 +1518,6 @@
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
-
-"@types/sizzle@*":
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
-  integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -6307,11 +6295,6 @@ jest@26.0.1:
     "@jest/core" "^26.0.1"
     import-local "^3.0.2"
     jest-cli "^26.0.1"
-
-jquery@3.5.1:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
-  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-base64@^2.1.8:
   version "2.5.2"


### PR DESCRIPTION
Following https://github.com/artsy/horizon/pull/160, another low-hanging fruit is to remove jQuery, which seems to be used in only 1 place. This reduces the JS bundle size by about 300 KB in development (30KB in production and gzipped).

## Before

See jQuery in the `application-*.js`.

![Screen Shot 2020-07-19 at 10 09 09 AM](https://user-images.githubusercontent.com/796573/87877080-4061dc80-c9aa-11ea-855a-42788b409ca3.png)

## After

![Screen Shot 2020-07-19 at 10 07 51 AM](https://user-images.githubusercontent.com/796573/87877083-448dfa00-c9aa-11ea-9431-efb4d914e5a7.png)

