### PR TITLE
Add db/seeds.rb for runnable (and re-runnable) seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,46 +32,12 @@ Or on localhost:
     # run the webpack-dev-server in a seperate terminal window for hot reloading and faster compilation:
     ./bin/webpack-dev-server
 
-The administrative UI can then be found at http://localhost:3000/admin. Create organizations, projects, profiles, and stages from there.
+The administrative UI can then be found at http://localhost:3000/admin.
 
-Artsy developers can use the db setup script to dump our staging data to a local development environment (requires VPN):
-
-```bash
-./bin/pull_data
-```
-
-Alternatively, here's an example using the console:
-
-```ruby
-org = Organization.create!(name: 'Acme')
-website = org.projects.create!(name: 'acme.org')
-heroku = org.profiles.create!(
-  name: 'heroku',
-  basic_username: 'heroku',
-  basic_password: '<heroku_token>'
-)
-github_aws = org.profiles.create!(
-  name: 'github/aws',
-  basic_username: 'github',
-  basic_password: '<github_token>',
-  environment: {'AWS_ACCESS_KEY_ID' => '<aws_id>', 'AWS_SECRET_ACCESS_KEY' => '<aws_secret>'}
-)
-website.stages.create!(
-  name: 'master',
-  git_remote: 'https://github.com/acme/website.git',
-  profile: github_aws
-)
-website.stages.create!(
-  name: 'staging',
-  git_remote: 'https://git.heroku.com/acme-website-staging.git',
-  profile: heroku
-)
-website.stages.create!(
-  name: 'production',
-  git_remote: 'https://git.heroku.com/acme-website-production.git',
-  profile: heroku
-)
-```
+To load representative data for development, you have several options:
+* Create organizations, projects, profiles, and stages from the administrative UI.
+* Use the `./bin/pull_data` script to copy data from staging (requires VPN and Artsy developer credentials).
+* Run the `db:seed` rake task (or `db:seed:replant` to re-seed).
 
 Once the cron has run, its snapshots are visible from the `/projects` page.
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,85 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+artsy_org = Organization.create!(name: 'artsy')
+
+github_aws_profile = artsy_org.profiles.create!(
+  name: 'github/aws',
+  basic_username: 'github',
+  basic_password: '<github_token>',
+  environment: {'AWS_ACCESS_KEY_ID' => '<aws_id>', 'AWS_SECRET_ACCESS_KEY' => '<aws_secret>'}
+)
+heroku_profile = artsy_org.profiles.create!(
+  name: 'heroku',
+  basic_username: 'heroku',
+  basic_password: '<heroku_token>'
+)
+
+candela_project = artsy_org.projects.create!(
+  name: 'candela',
+  description: 'send analytics data based on warehouse data',
+  tags: ['galleries', 'auctions']
+)
+master_stage = candela_project.stages.create!(
+  name: 'master',
+  git_remote: 'https://github.com/artsy/candela.git',
+  profile: github_aws_profile
+)
+staging_stage = candela_project.stages.create!(
+  name: 'staging',
+  git_remote: 'https://github.com/artsy/candela.git',
+  profile: github_aws_profile,
+  hokusai: 'staging'
+)
+production_stage = candela_project.stages.create!(
+  name: 'production',
+  git_remote: 'https://github.com/artsy/candela.git',
+  profile: github_aws_profile,
+  hokusai: 'production'
+)
+production_stage.deploy_strategies.create!(
+  provider: 'github pull request',
+  profile: github_aws_profile,
+  automatic: true,
+  arguments: { base: 'release', head: 'staging' }
+)
+snapshot = candela_project.snapshots.create!(refreshed_at: 5.minutes.ago)
+snapshot.comparisons.create!(
+  behind_stage: production_stage,
+  ahead_stage: staging_stage,
+  released: false,
+  description: [
+    'e033cf057 2020-07-20 Update prop name for clarity (Will Willson, will@example.com)',
+    '0401b9ffb 2020-07-17 Jest Force Garbage Collection (Tina Tinason, tina@example.com)'
+  ]
+)
+snapshot.comparisons.create!(
+  behind_stage: staging_stage,
+  ahead_stage: master_stage,
+  released: true,
+  description: []
+)
+candela_project.update!(snapshot: snapshot)
+candela_project.deploy_blocks.create!(description: 'an example deploy block')
+
+charge_project = artsy_org.projects.create!(
+  name: 'charge',
+  description: 'create and pay auction invoices',
+  tags: ['auctions']
+)
+charge_master_stage = charge_project.stages.create!(
+  name: 'master',
+  git_remote: 'https://github.com/artsy/charge.git',
+  profile: github_aws_profile
+)
+charge_staging_stage = charge_project.stages.create!(
+  name: 'staging',
+  git_remote: 'https://git.heroku.com/charge-staging.git',
+  profile: heroku_profile
+)
+charge_production_stage = charge_project.stages.create!(
+  name: 'production',
+  git_remote: 'https://git.heroku.com/charge-production.git',
+  profile: heroku_profile
+)


### PR DESCRIPTION
This is a small experiment with database-seeding. I haven't personally worked on any project that used seeds extensively, but they're meant for _exactly_ the kinds of situations we've been discussing: easing initial development and creating a known baseline state.

The `db/seeds.rb` file is the standard rails location for seed data. We could break the operations up among separate files, but I thought this was a manageable size to start. What's nice is that this is just ruby code and it can access our application logic, validations, etc. as necessary, so hopefully this doesn't get too boilerplate-y or repetitive.

The net result is that developers can run the `db:seed` rake task locally _or with `hokusai dev ...`_ to get some minimal data into their environment. If they've made changes and wish to reset, the `db:seed:replant` tasks accomplishes that. The faked comparison data ends up looking like:

![](https://p26.f0.n0.cdn.getcloudapp.com/items/Z4uY0zYO/Screen%20Shot%202020-07-20%20at%203.54.04%20PM.png?v=e2be519e3d15a7378b390a2e5a5c335c)

**TO DO (separately)**
This seed data contains placeholders for sensitive data. A next step will be to load those secrets from a shared location (or just prompt the developer for them) so that the operations depending on them (like git, kubernetes, or AWS-authorized calls) can succeed locally.