### PR TITLE
Bad version of sharing config across local development environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ The administrative UI can then be found at http://localhost:3000/admin.
 
 To load representative data for development, you have several options:
 * Create organizations, projects, profiles, and stages from the administrative UI.
+* Run the `db:seed` rake task (or `db:seed:replant` to re-seed). The same command can be run via `hokusai dev run ...` for docker-based development.
 * Use the `./bin/pull_data` script to copy data from staging (requires VPN and Artsy developer credentials).
-* Run the `db:seed` rake task (or `db:seed:replant` to re-seed).
 
 Once the cron has run, its snapshots are visible from the `/projects` page.
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,7 +7,12 @@
 #   Character.create(name: 'Luke', movie: movies.first)
 
 secrets_path = "#{ENV['HOME']}/.artsy/secrets.yml"
-secrets = File.exist?(secrets_path) ? YAML.load(File.read(secrets_path)) : {}
+secrets = if File.exist?(secrets_path)
+  $stderr.puts "Loading configuration from #{secrets_path}..."
+  YAML.load(File.read(secrets_path))
+else
+  {}
+end
 
 artsy_org = Organization.create!(name: 'artsy')
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,18 +6,24 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+secrets_path = "#{ENV['HOME']}/.artsy/secrets.yml"
+secrets = File.exist?(secrets_path) ? YAML.load(File.read(secrets_path)) : {}
+
 artsy_org = Organization.create!(name: 'artsy')
 
 github_aws_profile = artsy_org.profiles.create!(
   name: 'github/aws',
   basic_username: 'github',
-  basic_password: '<github_token>',
-  environment: {'AWS_ACCESS_KEY_ID' => '<aws_id>', 'AWS_SECRET_ACCESS_KEY' => '<aws_secret>'}
+  basic_password: secrets.fetch('github_token', '<github_token>'),
+  environment: {
+    'AWS_ACCESS_KEY_ID' => secrets.fetch('aws_access_key_id', '<aws_id>'),
+    'AWS_SECRET_ACCESS_KEY' => secrets.fetch('aws_secret_access_key', '<aws_secret>')
+  }
 )
 heroku_profile = artsy_org.profiles.create!(
   name: 'heroku',
   basic_username: 'heroku',
-  basic_password: '<heroku_token>'
+  basic_password: secrets.fetch('heroku_token', '<heroku_token>')
 )
 
 candela_project = artsy_org.projects.create!(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,10 +6,10 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-secrets_path = "#{ENV['HOME']}/.artsy/secrets.yml"
-secrets = if File.exist?(secrets_path)
-  $stderr.puts "Loading configuration from #{secrets_path}..."
-  YAML.load(File.read(secrets_path))
+shared_path = "#{ENV['HOME']}/.artsy/shared.yml"
+shared = if File.exist?(shared_path)
+  $stderr.puts "Loading shared configuration from #{shared_path}..."
+  YAML.load(File.read(shared_path))
 else
   {}
 end
@@ -19,16 +19,16 @@ artsy_org = Organization.create!(name: 'artsy')
 github_aws_profile = artsy_org.profiles.create!(
   name: 'github/aws',
   basic_username: 'github',
-  basic_password: secrets.fetch('github_token', '<github_token>'),
+  basic_password: shared.fetch('github_token', '<github_token>'),
   environment: {
-    'AWS_ACCESS_KEY_ID' => secrets.fetch('aws_access_key_id', '<aws_id>'),
-    'AWS_SECRET_ACCESS_KEY' => secrets.fetch('aws_secret_access_key', '<aws_secret>')
+    'AWS_ACCESS_KEY_ID' => shared.fetch('aws_access_key_id', '<aws_id>'),
+    'AWS_SECRET_ACCESS_KEY' => shared.fetch('aws_secret_access_key', '<aws_secret>')
   }
 )
 heroku_profile = artsy_org.profiles.create!(
   name: 'heroku',
   basic_username: 'heroku',
-  basic_password: secrets.fetch('heroku_token', '<heroku_token>')
+  basic_password: shared.fetch('heroku_token', '<heroku_token>')
 )
 
 candela_project = artsy_org.projects.create!(

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -16,6 +16,7 @@ services:
       - 8443:8443
     volumes:
       - ../:/app
+      - ~/.artsy:/home/deploy/.artsy
     depends_on:
       - horizon-postgres
       - horizon-redis


### PR DESCRIPTION
This is just a thought checkpoint. I plan to close this and iterate some more.

### Problem

Productive local development depends on multiple running services, each with configuration (keys, URLs...), data (users, partners, access control lists...), networking (hostnames, ports...), and dependencies (databases, caches, language versions...) set up to operate well together. In practice this is difficult to get right, so end-to-end development and QA just doesn't happen or has to wait for multiple changes to reach staging.

### Solution

The aim of [PLATFORM-2640](https://artsyproduct.atlassian.net/browse/PLATFORM-2640) is to make this kind of coordinated set-up easy and automatic. This PR concerns itself with the need for some sensitive or shared values in a service's seed data or ENV. The criteria I have in mind for evaluating solutions include:

* As simple as possible (so in the case of rails backends, reusing built-in `seed` support as in https://github.com/artsy/horizon/pull/165).
* Work when developing on localhost _or_ docker.
* Keep secrets out of repos and docker images.
* Work for open- and closed-source projects.
* Minimize set-up required in each repo (ideally, it's completely optional so doesn't unnecessarily complicate localized work).
* Shouldn't conflict with developers' other activities or across repos (e.g., by clobbering AWS credentials in their env or requiring a certain default language version).
* Since repos use different labels for the same values, and sometimes require different values for similarly-labeled configs, any solution must allow mapping from shared config names to the required in-repo names. E.g., what Volt calls `gravity_client_id` might be `volt_client_id` to Gravity, but should ideally only be present once in the shared data.
* It should be simple to refresh local set-up from an updated source (e.g., as new keys or data get added).

### This PR...

...updates the seed task to respect an optional `~/.artsy/shared.yml` file that provides shared values. In Horizon's simple case, these include Heroku, Github, and AWS keys. Docker-based development accesses these by defining a "volume" that maps the local `~/.artsy` directory to `/home/deploy/.artsy` in the container.

Developers with a `~/.artsy/shared.yml` file get a decent set-up just by running `rake db:seed` or `db:seed:replant`, both locally and with `hokusai dev ...`. My `shared.yml` file looks like:

```yaml
---
aws_access_key_id: REDACTED
aws_secret_access_key: REDACTED
github_token: REDACTED
heroku_token: REDACTED
```

We discussed some reasons why this approach would be problematic:
* Docker-compose volumes come with their own problems, including requiring particular clean-up or not refreshing when expected.
* The `~/.artsy` directory is pretty novel and atypical compared to how we supply most other configuration via ENV.