### PR TITLE
Source shared config from S3 to aid both local and docker development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,6 +13,7 @@ README.md
 # Rails
 #
 .env
+.env.shared
 .env.sample
 *.rbc
 capybara-*.html

--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-# Place any custom/local configuraton here
+# Place any custom/local configuration here

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+# Place any custom/local configuraton here

--- a/.foreman
+++ b/.foreman
@@ -1,0 +1,1 @@
+env: .env.shared,.env

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 /config/master.key
 
 .env
+.env.shared
 *.dump
 
 /public/packs

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Visual representations of release pipelines.
 
 ## Setup
 
-The setup script will install prerequisites and create seed data:
+Local development depends on a `.env.shared` file (sourced from S3) and a `.env` file for any overrides or additions. The setup script will initialize these in addition to installing prerequisites and generating seed data:
 
     ./bin/setup
 
@@ -30,19 +30,12 @@ Then, to develop with docker:
 Or on localhost:
 
     yarn install
-    foreman run --env .env.shared,.env bundle exec rails server
+    foreman run bundle exec rails server
 
     # run the webpack-dev-server in a seperate terminal window for hot reloading and faster compilation:
     ./bin/webpack-dev-server
 
-The administrative UI can then be found at http://localhost:3000/admin.
-
-To load representative data for development, you have several options:
-* Create organizations, projects, profiles, and stages from the administrative UI.
-* Run the `db:seed` rake task (or `db:seed:replant` to re-seed). The same command can be run via `hokusai dev run ...` for docker-based development.
-* Use the `./bin/pull_data` script to copy data from staging (requires VPN and Artsy developer credentials).
-
-Once the cron has run, its snapshots are visible from the `/projects` page.
+The UI can then be found at http://localhost:3000.
 
 ## Design
 

--- a/README.md
+++ b/README.md
@@ -18,16 +18,19 @@ Visual representations of release pipelines.
 
 ## Setup
 
-With docker:
+The setup script will install prerequisites and create seed data:
 
-    hokusai dev run 'bundle exec rake db:migrate'
+    ./bin/setup
+
+Then, to develop with docker:
+
+    hokusai dev run 'bundle exec rake db:prepare db:seed:replant'
     hokusai dev start
 
 Or on localhost:
 
-    bundle exec rails db:prepare
     yarn install
-    bundle exec rails server
+    foreman run --env .env.shared,.env bundle exec rails server
 
     # run the webpack-dev-server in a seperate terminal window for hot reloading and faster compilation:
     ./bin/webpack-dev-server
@@ -36,8 +39,8 @@ The administrative UI can then be found at http://localhost:3000/admin.
 
 To load representative data for development, you have several options:
 * Create organizations, projects, profiles, and stages from the administrative UI.
+* Run the `db:seed` rake task (or `db:seed:replant` to re-seed). The same command can be run via `hokusai dev run ...` for docker-based development.
 * Use the `./bin/pull_data` script to copy data from staging (requires VPN and Artsy developer credentials).
-* Run the `db:seed` rake task (or `db:seed:replant` to re-seed).
 
 Once the cron has run, its snapshots are visible from the `/projects` page.
 

--- a/bin/setup
+++ b/bin/setup
@@ -30,18 +30,12 @@ FileUtils.chdir APP_ROOT do
     FileUtils.cp '.env.example', '.env'
   end
 
-  puts "\n== Creating .env.shared (for shared configuration) =="
-  puts "WARNING: No shared Artsy environment found." unless ENV['ARTSY_ENV']
-  File.write '.env.shared', <<-FILE
-ARTSY_AWS_ACCESS_KEY_ID=#{ENV['ARTSY_AWS_ACCESS_KEY_ID']}
-ARTSY_AWS_SECRET_ACCESS_KEY=#{ENV['ARTSY_AWS_SECRET_ACCESS_KEY']}
-ARTSY_GITHUB_TOKEN=#{ENV['ARTSY_GITHUB_TOKEN']}
-ARTSY_HEROKU_TOKEN=#{ENV['ARTSY_HEROKU_TOKEN']}
-  FILE
+  puts "\n== Downloading .env.shared (for shared configuration) =="
+  system! 'aws s3 cp s3://artsy-citadel/dev/.env.horizon .env.shared'
 
   puts "\n== Installing foreman for local development =="
   system! 'gem install foreman'
 
   puts "\n== Preparing database =="
-  system! 'foreman run --env .env.shared,.env bin/rails db:setup db:seed'
+  system! 'foreman run bin/rails db:setup db:seed'
 end

--- a/bin/setup
+++ b/bin/setup
@@ -25,12 +25,23 @@ FileUtils.chdir APP_ROOT do
   #   FileUtils.cp 'config/database.yml.sample', 'config/database.yml'
   # end
 
+  unless File.exist?('.env')
+    puts "\n== Creating .env (for any custom configuration) =="
+    FileUtils.cp '.env.example', '.env'
+  end
+
+  puts "\n== Creating .env.shared (for shared configuration) =="
+  puts "WARNING: No shared Artsy environment found." unless ENV['ARTSY_ENV']
+  File.write '.env.shared', <<-FILE
+ARTSY_AWS_ACCESS_KEY_ID=#{ENV['ARTSY_AWS_ACCESS_KEY_ID']}
+ARTSY_AWS_SECRET_ACCESS_KEY=#{ENV['ARTSY_AWS_SECRET_ACCESS_KEY']}
+ARTSY_GITHUB_TOKEN=#{ENV['ARTSY_GITHUB_TOKEN']}
+ARTSY_HEROKU_TOKEN=#{ENV['ARTSY_HEROKU_TOKEN']}
+  FILE
+
+  puts "\n== Installing foreman for local development =="
+  system! 'gem install foreman'
+
   puts "\n== Preparing database =="
-  system! 'bin/rails db:prepare'
-
-  puts "\n== Removing old logs and tempfiles =="
-  system! 'bin/rails log:clear tmp:clear'
-
-  puts "\n== Restarting application server =="
-  system! 'bin/rails restart'
+  system! 'foreman run --env .env.shared,.env bin/rails db:setup db:seed'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,18 +6,27 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+if ENV['ARTSY_ENV']
+  $stderr.puts 'Sourcing seed data from shared Artsy environment variables.'
+else
+  $stderr.puts 'No shared Artsy environment found. Falling back to defaults.'
+end
+
 artsy_org = Organization.create!(name: 'artsy')
 
 github_aws_profile = artsy_org.profiles.create!(
   name: 'github/aws',
   basic_username: 'github',
-  basic_password: '<github_token>',
-  environment: {'AWS_ACCESS_KEY_ID' => '<aws_id>', 'AWS_SECRET_ACCESS_KEY' => '<aws_secret>'}
+  basic_password: ENV['ARTSY_GITHUB_TOKEN'] || '<github_token>',
+  environment: {
+    'AWS_ACCESS_KEY_ID' => ENV['ARTSY_AWS_ACCESS_KEY_ID'] || '<aws_id>',
+    'AWS_SECRET_ACCESS_KEY' => ENV['ARTSY_AWS_SECRET_ACCESS_KEY'] || '<aws_secret>'
+  }
 )
 heroku_profile = artsy_org.profiles.create!(
   name: 'heroku',
   basic_username: 'heroku',
-  basic_password: '<heroku_token>'
+  basic_password: ENV['ARTSY_HEROKU_TOKEN'] || '<heroku_token>'
 )
 
 candela_project = artsy_org.projects.create!(

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -2,6 +2,9 @@
 version: "2"
 services:
   horizon:
+    env_file:
+      - ../.env.shared
+      - ../.env
     environment:
       - RAILS_ENV=development
       - RAILS_LOG_TO_STDOUT=true


### PR DESCRIPTION
The approach in https://github.com/artsy/horizon/pull/175 depended on developers having a `~/.artsy/shared.yml` with common values. This PR demonstrates how we could instead rely on values from the developer's environment.

Given a developer has a `~/.artsy` file containing the following:

```bash
export ARTSY_ENV=1

export ARTSY_AWS_ACCESS_KEY_ID=REDACTED
export ARTSY_AWS_SECRET_ACCESS_KEY=REDACTED
export ARTSY_GITHUB_TOKEN=REDACTED
export ARTSY_HEROKU_TOKEN=REDACTED
```

...and has a `source ~/.artsy` line somewhere in their `.bash_profile` or `.zshrc` (or whatever), these `ARTSY_`-namespaced values will be available in their environment.

The `bin/setup` script in this repo takes care of initializing a `.env.shared` file with whatever subset the project relies on, possibly with different keys. It also initializes a `.env` file for any local configuration or overrides. (This file is empty in Horizon's case, but a place for overrides is important nonetheless so `.env.shared` can always be cleanly updated later.)

At this point, local development can respect these values using `foreman` like:

```bash
foreman run --env .env.shared,.env bundle exec rails server
```

And docker-based development respects them via the `env_file` declaration.

### What happens when shared or local config changes

When shared configuration changes, the `~/.artsy` file must be updated. This isn't handled in this PR, but that could happen via 1Password, `awscli`, or the team-wide [setup script](https://github.com/artsy/potential/blob/master/scripts/setup) in Potential.

When the project's use of that shared configuration changes, re-running `bin/setup` refreshes the local `.env.shared` file. If necessary, running the built-in `db:seed:replant` task will replace seed data.

### Rejected alternatives

* We could simply list all of the necessary ENV variables in `development.yml`, but this wouldn't be reusable for local development via foreman. In Horizon's case, where the values are only necessary for the seed task and not running the application, it would also be a lot of unfortunate noise in the file. Pushing them into a separate file seemed cleaner.
* Namespacing shared values with `ARTSY_...` is annoying but I really wanted to avoid clobbering other ENV (like `AWS_ACCESS_KEY_ID`).
* It's ugly how the `setup` script writes the `.env.shared` file as a string. It would be nicer and more self-describing for a `.env.shared` file to be committed to the repo and have lines like `FOO=${ARTSY_FOO}`, but I couldn't figure out how to accomplish this without a lot of custom bash-scripting.

Overall I'm worried this pattern is a little fragile. Feedback and ideas for improvement?