### PR TITLE
Support automatic merging of release PRs after designated period of time

### DIFF
--- a/app/models/deploy_strategy.rb
+++ b/app/models/deploy_strategy.rb
@@ -8,7 +8,7 @@ class DeployStrategy < ApplicationRecord
     'github pull request' => %w[base head]
   }.freeze
   SUPPORTED_ARGUMENTS = {
-    'github pull request' => %w[base head repo]
+    'github pull request' => %w[base head repo merge_after]
   }.freeze
 
   belongs_to :stage

--- a/spec/models/deploy_strategy_spec.rb
+++ b/spec/models/deploy_strategy_spec.rb
@@ -55,6 +55,6 @@ RSpec.describe DeployStrategy, type: :model do
         provider: 'github pull request',
         arguments: { foo: 'bar' }
       )
-    end.to raise_error(/can only include base, head, and repo/)
+    end.to raise_error(/can only include base, head, repo/)
   end
 end


### PR DESCRIPTION
One step toward more continuous deployment as described in [PLATFORM-2682](https://artsyproduct.atlassian.net/browse/PLATFORM-2682).

This adds support for an optional `merge_after` argument for `DeployStrategy`s. If a release PR is still open when the specified number of seconds has passed, the PR is merged. This is skipped when unresolved `DeployBlock`s exist thanks to [this existing logic](https://github.com/artsy/horizon/blob/faad9e4b391055ba553103926b53d35c5a83355b/app/services/comparison_service.rb#L59-L62) (and [test](https://github.com/artsy/horizon/blob/faad9e4b391055ba553103926b53d35c5a83355b/spec/features/comparisons_spec.rb#L89)).

This change does _not_ fulfill the requirements described in the ticket around Slack notifications. I figured that could come separately since it will involve new gem dependencies, options, and complexity, plus the automatic merging is completely opt-in for projects in the meantime. I.e., it will only be enabled for the 1 project I test it on, probably Horizon.