### PR TITLE
Require BASIC_AUTH_PASS before booting in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 # Place any custom/local configuration here
+BASIC_AUTH_PASS=REPLACEME

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  if !Rails.env.test? && Horizon.config[:basic_auth_pass].present?
+  if Horizon.config[:basic_auth_pass].present?
     http_basic_authenticate_with(
       name: Horizon.config[:basic_auth_user],
       password: Horizon.config[:basic_auth_pass]

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -8,3 +8,7 @@ Horizon.config = {
   minimum_version_ruby: ENV['MINIMUM_VERSION_RUBY'],
   minimum_version_node: ENV['MINIMUM_VERSION_NODE']
 }
+
+if Rails.env.production? # require certain config before booting in production
+  raise 'BASIC_AUTH_PASS is required' if Horizon.config.basic_auth_pass.blank?
+end


### PR DESCRIPTION
This came up during incident review.

(I need to merge a small commit to test out the automatic PR-merging, so I'll self-merge this.)