### PR TITLE
Enforce basic auth only for admin area

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,14 +1,16 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  if Horizon.config[:basic_auth_pass].present?
-    http_basic_authenticate_with(
+  private
+
+  def admin_basic_auth
+    return if Horizon.config[:basic_auth_pass].blank?
+
+    http_basic_authenticate_or_request_with(
       name: Horizon.config[:basic_auth_user],
       password: Horizon.config[:basic_auth_pass]
     )
   end
-
-  private
 
   def set_admin_timezone
     Time.zone = 'Eastern Time (US & Canada)'

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -171,6 +171,7 @@ ActiveAdmin.setup do |config|
   # https://github.com/svenfuchs/i18n/blob/master/lib%2Fi18n%2Fbackend%2Fbase.rb#L52
   #
   config.localize_format = :long
+  config.before_action :admin_basic_auth
   config.before_action :set_admin_timezone
 
   # == Setting a Favicon

--- a/spec/features/admin_spec.rb
+++ b/spec/features/admin_spec.rb
@@ -24,4 +24,25 @@ RSpec.feature 'Administration', type: :feature do
     click_button 'Create Project'
     expect(page).to have_content('Shipping')
   end
+
+  scenario 'enforce basic auth on admin areas', type: :feature do
+    allow(Horizon).to receive(:config).and_return(
+      basic_auth_user: 'admin',
+      basic_auth_pass: 'secret'
+    )
+
+    visit '/admin'
+    expect(page.status_code).to eq(401)
+
+    page.driver.header('Authorization', ActionController::HttpAuthentication::Basic.encode_credentials('admin', 'pass'))
+    visit '/admin'
+    expect(page.status_code).to eq(401)
+
+    page.driver.header(
+      'Authorization',
+      ActionController::HttpAuthentication::Basic.encode_credentials('admin', 'secret')
+    )
+    visit '/admin'
+    expect(page.status_code).to eq(200)
+  end
 end


### PR DESCRIPTION
Minor follow-up from single sign-on ([PLATFORM-2711](https://artsyproduct.atlassian.net/browse/PLATFORM-2711)): enforce basic authentication only around the activeadmin area rather than the whole application.