### PR TITLE
Optionally notify to Slack prior to merging release PRs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ end
 
 group :test do
   gem 'capybara' # feature specs
+  gem 'webmock' # stub HTTP requests
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.6)
     diff-lcs (1.3)
     erubi (1.9.0)
@@ -112,6 +114,7 @@ GEM
     has_scope (0.7.2)
       actionpack (>= 4.1)
       activesupport (>= 4.1)
+    hashdiff (1.0.1)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     inherited_resources (1.11.0)
@@ -247,6 +250,7 @@ GEM
       parser (>= 2.7.0.1)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -291,6 +295,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.8.3)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     webpacker (5.1.1)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
@@ -330,6 +338,7 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock
   webpacker (~> 5.1)
 
 RUBY VERSION

--- a/app/admin/deploy_strategies.rb
+++ b/app/admin/deploy_strategies.rb
@@ -23,7 +23,10 @@ ActiveAdmin.register DeployStrategy do
       f.input :provider, as: :select, collection: DeployStrategy::PROVIDERS
       f.input :profile
       f.input :automatic
-      f.input :arguments_input, label: 'Arguments (JSON)'
+      f.input :arguments_input,
+              label: 'Arguments (JSON)',
+              hint: 'Supported properties: base (branch), head (branch), repo (e.g., org/project), " +
+              "merge_after (sec.), merge_prior_warning (sec., default 3600) slack_webhook_url, warned_pull_request_url'
     end
     f.actions
   end

--- a/app/models/deploy_strategy.rb
+++ b/app/models/deploy_strategy.rb
@@ -8,7 +8,7 @@ class DeployStrategy < ApplicationRecord
     'github pull request' => %w[base head]
   }.freeze
   SUPPORTED_ARGUMENTS = {
-    'github pull request' => %w[base head repo merge_after]
+    'github pull request' => %w[base head repo merge_after slack_webhook_url warned_pull_request_url]
   }.freeze
 
   belongs_to :stage

--- a/app/models/deploy_strategy.rb
+++ b/app/models/deploy_strategy.rb
@@ -8,7 +8,15 @@ class DeployStrategy < ApplicationRecord
     'github pull request' => %w[base head]
   }.freeze
   SUPPORTED_ARGUMENTS = {
-    'github pull request' => %w[base head repo merge_after slack_webhook_url warned_pull_request_url]
+    'github pull request' => [
+      'base', # e.g., "release"
+      'head', # e.g., "staging"
+      'repo', # e.g., "artsy/candela"
+      'merge_after', # seconds after which to automatically merge release PRs (default 86400 or 24 hours)
+      'merge_prior_warning', # when to notify slack about a pending merge, in seconds (default 3600 or 1 hour)
+      'slack_webhook_url', # for notifying prior to merging release PRs
+      'warned_pull_request_url' # used internally to avoid repeat notifications
+    ]
   }.freeze
 
   belongs_to :stage

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -41,9 +41,12 @@ class DeployService
       if Time.now > merge_at # merge release PR automatically
         github_client.merge_pull_request(github_repo, pull_request.number)
         return
-      elsif Time.now > (merge_at - MERGE_PRIOR_WARNING) &&
-            (webhook_url = deploy_strategy.arguments['slack_webhook_url']) &&
-            deploy_strategy.arguments['warned_pull_request_url'] != pull_request.html_url
+      end
+
+      warn_at = merge_at - deploy_strategy.arguments.fetch('merge_prior_warning', MERGE_PRIOR_WARNING)
+      if Time.now > warn_at &&
+         (webhook_url = deploy_strategy.arguments['slack_webhook_url']) &&
+         deploy_strategy.arguments['warned_pull_request_url'] != pull_request.html_url
         deliver_slack_webhook(pull_request, webhook_url)
         deploy_strategy.update!(
           arguments: deploy_strategy.arguments.merge(warned_pull_request_url: pull_request.html_url)

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -110,7 +110,7 @@ RSpec.feature 'Deploys', type: :feature do
   it 'notifies Slack prior to automatically merging release PR' do
     strategy.update!(arguments: strategy.arguments.merge(
       merge_after: 26.hours.to_i,
-      merge_prior_warning: 60.minutes.to_i,
+      merge_prior_warning: 75.minutes.to_i,
       slack_webhook_url: 'https://hooks.slack.com/services/foo/bar/baz'
     ))
     allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
@@ -121,7 +121,9 @@ RSpec.feature 'Deploys', type: :feature do
       .and_return([assigned_github_pull_request])
     expect_any_instance_of(Octokit::Client).not_to receive(:merge_pull_request)
     webhook = stub_request(:post, strategy.arguments['slack_webhook_url']).with(
-      body: '{"text":"The following changes will be released shortly: https://github.com/artsy/candela/pull/342"}',
+      body: {
+        text: 'The following changes will be released in about 1 hour: https://github.com/artsy/candela/pull/342'
+      }.to_json,
       headers: { 'Content-Type' => 'application/json' }
     ).to_return(status: 201)
 

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -110,6 +110,7 @@ RSpec.feature 'Deploys', type: :feature do
   it 'notifies Slack prior to automatically merging release PR' do
     strategy.update!(arguments: strategy.arguments.merge(
       merge_after: 26.hours.to_i,
+      merge_prior_warning: 60.minutes.to_i,
       slack_webhook_url: 'https://hooks.slack.com/services/foo/bar/baz'
     ))
     allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -32,6 +32,10 @@ RSpec.feature 'Deploys', type: :feature do
       double('commit', author)
     ]
   end
+  let(:github_pull_request) { double(number: 42, assignee: nil, created_at: 25.hours.ago) }
+  let(:assigned_github_pull_request) do
+    double(number: 42, assignee: 'jane', created_at: 25.hours.ago, html_url: 'https://github.com/artsy/candela/pull/342')
+  end
 
   it 'raises error unless profile.basic_password is present' do
     invalid_strategy = stages.last.deploy_strategies.create!(
@@ -47,7 +51,7 @@ RSpec.feature 'Deploys', type: :feature do
   it 'sends an Octokit request to create pull request' do
     expect_any_instance_of(Octokit::Client).to receive(:create_pull_request)
       .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_return(double(number: 42))
+      .and_return(github_pull_request)
     allow_any_instance_of(Octokit::Client).to receive(:pull_request_commits).and_return([])
     DeployService.new(strategy).start
   end
@@ -55,7 +59,7 @@ RSpec.feature 'Deploys', type: :feature do
   it 'assigns deploy pull request to appropriate user' do
     expect_any_instance_of(Octokit::Client).to receive(:create_pull_request)
       .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_return(double(number: 42))
+      .and_return(github_pull_request)
     allow_any_instance_of(Octokit::Client).to receive(:pull_request_commits)
       .with('artsy/candela', 42)
       .and_return([
@@ -75,7 +79,7 @@ RSpec.feature 'Deploys', type: :feature do
       .and_raise(Octokit::UnprocessableEntity)
     allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
       .with('artsy/candela', base: 'release', head: 'staging')
-      .and_return([double(number: 42, assignee: nil)])
+      .and_return([github_pull_request])
     allow_any_instance_of(Octokit::Client).to receive(:pull_request_commits)
       .with('artsy/candela', 42)
       .and_return([
@@ -97,9 +101,33 @@ RSpec.feature 'Deploys', type: :feature do
       .and_raise(Octokit::UnprocessableEntity)
     allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
       .with('artsy/candela', base: 'release', head: 'staging')
-      .and_return([double(number: 42, assignee: 'jane', created_at: 25.hours.ago)])
+      .and_return([assigned_github_pull_request])
     expect_any_instance_of(Octokit::Client).to receive(:merge_pull_request).with('artsy/candela', 42)
 
     DeployService.new(strategy).start
+  end
+
+  it 'notifies Slack prior to automatically merging release PR' do
+    strategy.update!(arguments: strategy.arguments.merge(
+      merge_after: 26.hours.to_i,
+      slack_webhook_url: 'https://hooks.slack.com/services/foo/bar/baz'
+    ))
+    allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
+      .with('artsy/candela', 'release', 'staging', anything, anything)
+      .and_raise(Octokit::UnprocessableEntity)
+    allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
+      .with('artsy/candela', base: 'release', head: 'staging')
+      .and_return([assigned_github_pull_request])
+    expect_any_instance_of(Octokit::Client).not_to receive(:merge_pull_request)
+    webhook = stub_request(:post, strategy.arguments['slack_webhook_url']).with(
+      body: '{"text":"The following changes will be released shortly: https://github.com/artsy/candela/pull/342"}',
+      headers: { 'Content-Type' => 'application/json' }
+    ).to_return(status: 201)
+
+    DeployService.new(strategy).start
+
+    # notification not repeated
+    DeployService.new(strategy).start
+    expect(webhook).to have_been_made.once
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -7,6 +7,8 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'webmock/rspec'
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
Add support for a new `slack_webhook_url` argument for a `DeployStrategy`. If provided, a simple message is sent to the channel specified by the webhook 1 hour before a pending release PR will be automatically merged.

Notes:
* Added `webmock` for making assertions about HTTP requests.
* Because this process runs often (every 10 minutes at the moment), I needed a way to remember if a particular release had already been notified about. I opted to store the URL representing the PR in the `DeployStrategy#arguments` field once it had been notified about. This is a bit of an ugly hack, but avoids embedding any assumptions about cron spacing in case that schedule changes or there are job delays.
* I opted for webhooks (from the many possible forms of Slack authentication) because they grant a specific app access to a specific channel, can be managed individually or app-wide, and are independent of particular user accounts. It also can be accomplished with just a `POST` request so seemed the simplest. To support this I created a "Horizon" app in our Slack workspace and generated an initial webhook (to me). I'll test with that once this is released.