### PR TITLE
Respect deploy blocks when releasing Horizon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   hokusai: artsy/hokusai@0.7.4
+  horizon: artsy/release@0.0.1
 
 not_staging_or_release: &not_staging_or_release
   filters:
@@ -25,6 +26,11 @@ only_release: &only_release
 workflows:
   build-deploy:
     jobs:
+      - horizon/block:
+          <<: *only_release
+          context: horizon
+          project_id: 38
+
       - hokusai/test:
           <<: *not_staging_or_release
 
@@ -42,3 +48,5 @@ workflows:
 
       - hokusai/deploy-production:
           <<: *only_release
+          requires:
+            - horizon/block


### PR DESCRIPTION
Following up from retro and the continuous deployment I enabled last week, let's ensure this project is only automatically released when no deploy-block exists.