### PR TITLE
Avoid assigning PRs to artsyit user

### DIFF
--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -99,7 +99,7 @@ class DeployService
     github_client
       .pull_request_commits(github_repo, pull_request.number)
       .flat_map { |c| [c.author, c.committer] }
-      .reject { |c| c.type == 'Bot' || c.login == 'web-flow' || c.login[/\bbot\b/] }
+      .reject { |c| c.type == 'Bot' || c.login == 'web-flow' || c.login == 'artsyit' || c.login[/\bbot\b/] }
       .group_by(&:login).map { |k, v| [v.size, k] }.sort.reverse.map(&:last)
       .detect { |l| github_client.check_assignee(github_repo, l) }
   end


### PR DESCRIPTION
I noticed that some deploy PRs were getting assigned to the `artsyit` user, probably as a result of `Merge on Green` merges.

This is a tiny but ugly fix... I wonder if we should generalize this to be configurable, maybe on an `Organization` basis. It's just tricky because the logic tries to do exact _and_ fuzzy matches.