### PR TITLE
Describe how to add new projects and deploy blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,38 @@ The UI can then be found at http://localhost:3000.
 - A `Stage` (such as "production") can have a `DeployStrategy` for automatically triggering releases. Currently only the "github pull request" provider is implemented. When defined, a deploy strategy will automatically start a release (e.g., by opening a pull request) when a diff exceeds a certain threshold.
 - `DeployBlock`s indicate that a project _should not_ be released. In addition to appearing on dashboards, any unresolved blocks will prevent new releases from being automated.
 
+## Adding a new project
+
+* Navigate to the [new project form](https://releases.artsy.net/admin/projects/new) and specify the name, description, and any tags (often _teams_) associated with the project.
+* Follow the _stages_ link and click to create a new stage:
+  * Choose a "profile" granting access to the repository or deployment (e.g., `github...`)
+  * Enter a name, usually `master` to start
+  * Enter a git remote (e.g., `https://github.com/artsy/delta.git`)
+  * Enter a tag pattern, branch, or hokusai environment associated with the deployment. For "master," these are usually blank.
+* Create additional stages for `staging` (usually specifying the `staging` hokusai environment), and `production` (usually specifying the `production` hokusai environment), if applicable.
+* After defining the `production` stage, follow the link to create a new _deploy strategy_.
+  * Choose `github pull request` as the provider
+  * Choose a profile granting necessary access (usually `github...`)
+  * Check the _Automatic_ box so that new release pull requests are opened automatically upon changes being pushed to staging.
+  * Provide arguments specifying the relevant branches (usually `{"base":"release","head":"staging"}`)
+* To _merge_ release pull requests automatically, specify the additional `merge_after` (in seconds) and--for an optional notification--`slack_webhook_url` (from [Horizon's slack settings](https://api.slack.com/apps/A0188C16QSZ/incoming-webhooks)). E.g.:
+
+```JSON
+{
+  "base": "release",
+  "head": "staging",
+  "merge_after": 86400,
+  "slack_webhook_url":"https://hooks.slack.com/services/T.../B.../Q..."
+}
+```
+
+## Adding a "deploy block"
+
+* Navigate to the [new deploy block form](https://releases.artsy.net/admin/deploy_blocks/new).
+* Choose a project and describe the reason for blocking deploys. Leave "resolved at" blank.
+* While the block is unresolved, Horizon will _not_ open new release pull requests or merge existing ones, but manual merges or deploys are still possible. CircleCI release workflows can use the `block` step defined in the [artsy/release](https://github.com/artsy/orbs/blob/master/src/release/release.yml) orb to short-circuit release builds.
+* Once resolved, click _edit_ in the [list of deploy blocks](https://releases-staging.artsy.net/admin/deploy_blocks) and specify a "resolved at" time.
+
 ## TO DO
 
 - ~~Support hokusai~~


### PR DESCRIPTION
Horizon has gained lots of new features over time, but I don't think we've documented how to _fully_ set up new projects yet.

Once this is in place, my hope is to update the [more general deployments playbook](https://github.com/artsy/README/blob/master/playbooks/deployments.md) to link to it.