### PR TITLE
Missing Folder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,7 @@
 !hokusai/
 !lib/
 !log/.keep
+!public/
 !Rakefile
 !spec/
 !storage/.keep


### PR DESCRIPTION
The `public` folder was not being copied into the docker container
causing the deploys to fail.