### PR TITLE
Fix hokusai dev.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,8 @@ COPY --chown=deploy:deploy . ./
 # Precompile Rails assets
 RUN bundle exec rake assets:precompile
 
+CMD ["bundle", "exec", "puma", "-C", "config/puma.rb"]
+
 FROM base AS production
 ENV PORT 3000
 EXPOSE 3000

--- a/hokusai/development.yml
+++ b/hokusai/development.yml
@@ -1,5 +1,10 @@
 ---
 version: "3.8"
+
+volumes:
+  horizon-node-modules:
+  horizon-public:
+
 services:
   horizon:
     build:
@@ -10,12 +15,17 @@ services:
       - RAILS_ENV=development
       - DATABASE_URL=postgresql://postgres:@horizon-postgres/horizon_development
       - REDIS_URL=redis://horizon-redis
+    env_file:
+      - ../.env.shared
+      - ../.env
     ports:
       - 3000:3000
       - 8080:8080
       - 8443:8443
     volumes:
       - ../:/app
+      - horizon-node-modules:/app/node_modules
+      - horizon-public:/app/public
     depends_on:
       - horizon-postgres
       - horizon-redis
@@ -26,3 +36,4 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
   horizon-redis:
     image: redis:3.2-alpine
+


### PR DESCRIPTION
Bumped into problems upon `hokusai dev start`.

- App container exits. That's because Dockerfile `builder` target has no CMD. Add CMD to run Puma. Alternative is to add `command` in development.yml. Do we have a preference?

- Browser reports error:
```
Showing /app/app/views/projects/index.html.erb where line #3 raised:

Webpacker can't find projects.js in /app/public/packs/manifest.json. Possible causes:
...
```
That's b/c `/app/public` in the container is masked by the repo's `public` dir which is mounted as part of the bind mount `../:/app`.

Not sure about the best solution. Here I create a `named volume` for the dir. At the first start of the stack, Docker creates the volume and fills it with content from the container. The volume's existence causes the dir to be omitted from bind mount. Subsequent starts of the stack will use whatever's in the volume, which might become stale and require manual deletion.

Also create a named volume for `node_modules` for same reason.

```
$ docker volume ls|grep horizon
local               hokusai_horizon-node-modules
local               hokusai_horizon-public
```
- Populate container env with env files.
