### PR TITLE
Troubleshoot prod refresh comparison cron alert.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -144,6 +144,9 @@ spec:
   jobTemplate:
     spec:
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: horizon-refresh-comparisons-cron


### PR DESCRIPTION
https://artsy.slack.com/archives/CA8SANW3W/p1609878932042300

In troubleshooting the alerts (job failed status) we noticed in the logs that many of those cron's pods are sigterm'd. At least some of the sigterms are from cluster autoscaler (of background node group).

Adding `safe-to-evict: false` annotation to cron spec, which will cause CA to skip (for scale down) a node that has such a pod.

I am not sure that this will actually reduce the alerts, b/c it seems a pod being sigterm'd does not necessarily cause its parent `job` to be marked as failed (there's been more instances of sigterms than alerts).