### PR TITLE
fix: switch to python3/pip3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,17 +6,16 @@ FROM artsy/ruby:2.6.6-node-12-yarn as base
 RUN apk update && apk --no-cache --quiet add --update \
     git \
     postgresql-dev \
-    py2-setuptools \
-    python2-dev \
     tzdata \
     && adduser -D -g '' deploy
 
 # support hokusai registry commands
 # horizon needs to compare production/staging envs of projects
-RUN ln -sf /usr/bin/easy_install-2.7 /usr/bin/easy_install && \
-    easy_install pip && \
-    pip install --upgrade pip && \
-    pip install --upgrade --no-cache-dir hokusai
+RUN apk update && apk --no-cache --quiet add --update \
+    build-base \
+    python3-dev \
+    py3-pip \
+    && pip install --upgrade --no-cache-dir hokusai
 
 # ---------------------------------------------------------
 # Build Image


### PR DESCRIPTION
pip doesn't work with python2 anymore.
since hokusai supports python3, switch to that and pip3.

https://app.circleci.com/pipelines/github/artsy/horizon/1298/workflows/883fe9ad-c4ae-4200-80fb-1ec2505843f7/jobs/1222

https://artsy.slack.com/archives/CA8SANW3W/p1611696568118800