### PR TITLE
fix: use hokusai beta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,15 @@ RUN apk update && apk --no-cache --quiet add --update \
 # horizon needs to compare production/staging envs of projects
 RUN apk update && apk --no-cache --quiet add --update \
     build-base \
-    python3-dev \
-    python3 \
-    py3-pip
+    openssl-dev
+
+RUN cd /tmp && \
+    wget -q https://www.python.org/ftp/python/3.5.8/Python-3.5.8.tgz && \
+    tar -xzf Python-3.5.8.tgz && \
+    cd Python-3.5.8 && \
+     ./configure 2>&1 > /dev/null && \
+    make install 2>&1 > /dev/null && \
+    rm -rf /tmp/Python-3.5.8*
 
 RUN python3 -m pip install git+https://github.com/artsy/hokusai.git
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ RUN apk update && apk --no-cache --quiet add --update \
 RUN apk update && apk --no-cache --quiet add --update \
     build-base \
     python3-dev \
-    py3-pip \
-    && pip install --upgrade --no-cache-dir hokusai
+    python3 \
+    py3-pip
+
+RUN python3 -m pip install git+https://github.com/artsy/hokusai.git
 
 # ---------------------------------------------------------
 # Build Image


### PR DESCRIPTION
Follow up to https://github.com/artsy/horizon/pull/315 in which we switched from python2/pip2 to python3/pip3.

Encountered a problem with hokusai registry images command under python3.

https://artsy.slack.com/archives/CA8SANW3W/p1611944044169800

We decided to switch horizon to hokusai beta release that has the fix, rather than waiting for an official release.

However, the beta Linux release is built on Debian (glibc) and does not work with Alpine (musl) which Horizon is based off.

https://artsy.slack.com/archives/CA8SANW3W/p1612374384229200

I attempted to build hokusai on alpine but encountered problem with Pyinstaller.

Therefore, for now, suggesting to install hokusai from Git (master). The install breaks with pip installed by apk. So install python/pip from source, and go with python3.5 since that's what hokusai officially supports.

Expecting builds to be slower and image size larger.