### PR TITLE
Guess Github repo based on git remote instead of org/project names

### DIFF
--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Project, type: :model do
   let(:org) { Organization.create! name: 'artsy' }
   let(:profile) { org.profiles.create!(basic_password: 'foo') }
-  let(:project) { org.projects.create!(name: 'eigen') }
+  let(:project) { org.projects.create!(name: 'eigen-ios') }
 
   before do
     (1..2).map do |i|
@@ -29,6 +29,16 @@ RSpec.describe Project, type: :model do
     snapshot.comparisons.create!(ahead_stage: project.stages.first, behind_stage: project.stages.last)
     project.update(snapshot: snapshot)
     expect(project.destroy).to be_present
+  end
+
+  describe 'github_repo' do
+    it 'draws from git remote when possible' do
+      expect(project.github_repo).to eq('artsy/eigen')
+    end
+
+    it 'falls back to org and project name' do
+      expect(Project.new(organization: org, name: 'hubble').github_repo).to eq('artsy/hubble')
+    end
   end
 
   describe 'deployment_type' do


### PR DESCRIPTION
Last week we split Eigen into 2 projects named `eigen-ios` and `eigen-android` to reflect its 2 parallel release pipelines. Over the weekend, there were alerts that the `cron:refresh_components` task was failing with:

```
rake aborted!
NoMethodError: undefined method `include?' for nil:NilClass
/app/app/services/project_data_service.rb:44:in `orbs'
/app/app/services/project_data_service.rb:25:in `update_computed_properties'
```

This was caused by failing to find a repository matching the updated projects' names. Elsewhere in the code, there's already some logic that digs into projects' git remote URLs in order to extract this information, so I just relocated it to the `Project` class where it can be shared by more callers.