### PR TITLE
feat: protect cronjob from eviction by cluster-autoscaler, and misc.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -32,7 +32,21 @@ spec:
           env:
             - name: PORT
               value: "8080"
-            - name: TRACE_AGENT_HOSTNAME
+            - name: PUMA_WORKERS
+              value: "1"
+            - name: PUMA_THREAD_MIN
+              value: "5"
+            - name: PUMA_THREAD_MAX
+              value: "5"
+            - name: RAILS_SERVE_STATIC_FILES
+              value: 'true'
+            - name: RAILS_LOG_TO_STDOUT
+              value: 'true'
+            - name: PUMA_BIND
+              value: 'tcp://0.0.0.0:8080'
+            - name: MALLOC_ARENA_MAX
+              value: "2"
+            - name: DATADOG_TRACE_AGENT_HOSTNAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
@@ -60,11 +74,11 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 10"]
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -105,7 +119,7 @@ spec:
     - port: 8080
       protocol: TCP
       name: http
-      targetPort: 8080
+      targetPort: horizon-http
   selector:
     app: horizon
     layer: application
@@ -134,7 +148,7 @@ spec:
               servicePort: http
 
 ---
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: horizon-refresh-comparisons-cron
@@ -143,6 +157,7 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 0
       template:
         metadata:
           annotations:
@@ -159,16 +174,16 @@ spec:
           restartPolicy: Never
           affinity:
             nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 1
-                  preference:
-                    matchExpressions:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
                       - key: tier
                         operator: In
                         values:
                           - background
+
 ---
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: horizon-refresh-components-cron
@@ -177,7 +192,11 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 3
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: horizon-refresh-components-cron
@@ -190,10 +209,9 @@ spec:
           restartPolicy: Never
           affinity:
             nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 1
-                  preference:
-                    matchExpressions:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
                       - key: tier
                         operator: In
                         values:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -32,7 +32,21 @@ spec:
           env:
             - name: PORT
               value: "8080"
-            - name: TRACE_AGENT_HOSTNAME
+            - name: PUMA_WORKERS
+              value: "1"
+            - name: PUMA_THREAD_MIN
+              value: "5"
+            - name: PUMA_THREAD_MAX
+              value: "5"
+            - name: RAILS_SERVE_STATIC_FILES
+              value: 'true'
+            - name: RAILS_LOG_TO_STDOUT
+              value: 'true'
+            - name: PUMA_BIND
+              value: 'tcp://0.0.0.0:8080'
+            - name: MALLOC_ARENA_MAX
+              value: "2"
+            - name: DATADOG_TRACE_AGENT_HOSTNAME
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
@@ -46,10 +60,10 @@ spec:
               containerPort: 8080
           resources:
             requests:
-              cpu: 100m
+              cpu: 50m
               memory: 256Mi
             limits:
-              memory: 500Mi
+              memory: 512Mi
           readinessProbe:
             httpGet:
               port: horizon-http
@@ -60,11 +74,11 @@ spec:
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sh", "-c", "sleep 10"]
-      dnsPolicy: Default
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -85,8 +99,8 @@ spec:
     apiVersion: apps/v1
     kind: Deployment
     name: horizon-web
-  minReplicas: 2
-  maxReplicas: 3
+  minReplicas: 1
+  maxReplicas: 2
   targetCPUUtilizationPercentage: 70
 
 ---
@@ -104,7 +118,7 @@ spec:
     - port: 8080
       protocol: TCP
       name: http
-      targetPort: 8080
+      targetPort: horizon-http
   selector:
     app: horizon
     layer: application
@@ -133,7 +147,7 @@ spec:
               servicePort: http
 
 ---
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: horizon-refresh-comparisons-cron
@@ -142,7 +156,11 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 3
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: horizon-refresh-comparisons-cron
@@ -155,16 +173,15 @@ spec:
           restartPolicy: Never
           affinity:
             nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 1
-                  preference:
-                    matchExpressions:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
                       - key: tier
                         operator: In
                         values:
                           - background
 ---
-apiVersion: batch/v2alpha1
+apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
   name: horizon-refresh-components-cron
@@ -173,7 +190,11 @@ spec:
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
+      backoffLimit: 3
       template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
           containers:
             - name: horizon-refresh-components-cron
@@ -186,10 +207,9 @@ spec:
           restartPolicy: Never
           affinity:
             nodeAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-                - weight: 1
-                  preference:
-                    matchExpressions:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
                       - key: tier
                         operator: In
                         values:


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-3197

- Set [safe-to-evict](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node) to false for crons so they cannot be evicted by cluster-autoscaler.
- Set [backoffLimit](https://kubernetes.io/docs/concepts/workloads/controllers/job/#pod-backoff-failure-policy) for crons to reduce retries.
- Adjust resources to reflect usage.
- Generally, true up with hokusai [template](https://github.com/artsy/artsy-hokusai-templates/tree/master/rails-puma/hokusai).