### PR TITLE
Fix: gracefully ignore unverified commits when choosing deploy assignee

### DIFF
--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -99,7 +99,7 @@ class DeployService
     github_client
       .pull_request_commits(github_repo, pull_request.number)
       .flat_map { |c| [c.author, c.committer] }
-      .reject { |c| c.type == 'Bot' || c.login == 'web-flow' || c.login == 'artsyit' || c.login[/\bbot\b/] }
+      .reject { |c| c.nil? || c.type == 'Bot' || c.login == 'web-flow' || c.login == 'artsyit' || c.login[/\bbot\b/] }
       .group_by(&:login).map { |k, v| [v.size, k] }.sort.reverse.map(&:last)
       .detect { |l| github_client.check_assignee(github_repo, l) }
   end


### PR DESCRIPTION
Horizon has been choking during its assignee-selection step, resulting in PRs without assignees and stale release data.

It turns out both `committer` and `author` can be `nil` on commit objects when "unverified." We hadn't encountered this until recently upon integrating external contractors. I'm not sure _why_ some commits are unverified or how to fix, but it's simple enough to exclude those commits from assignee logic.