### PR TITLE
fix: pip install failure.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,10 @@ RUN apk update && apk --no-cache --quiet add --update \
     build-base \
     openssl-dev \
     python3-dev \
-    py3-pip \
-    && pip install --upgrade --no-cache-dir hokusai
+    py3-pip
+
+RUN pip3 install --upgrade --no-cache-dir pip \
+    && pip3 install --upgrade --no-cache-dir hokusai
 
 # ---------------------------------------------------------
 # Build Image


### PR DESCRIPTION
fix:

```
ERROR: Command errored out with exit status 1: /usr/bin/python3 -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-osll045m/MarkupSafe/setup.py'"'"'; __file__='"'"'/tmp/pip-install-osll045m/MarkupSafe/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-grt1ef_w/install-record.txt --single-version-externally-managed --compile --install-headers /usr/include/python3.8/MarkupSafe Check the logs for full command output.
```

https://app.circleci.com/pipelines/github/artsy/horizon/1674/workflows/0f45afbb-8404-4a7b-a00a-af8b323c5a19/jobs/1628
