### PR TITLE
feat: allow comparison working dir to be specified via env.

### DIFF
--- a/app/services/releasecop_service.rb
+++ b/app/services/releasecop_service.rb
@@ -16,11 +16,11 @@ class ReleasecopService
   end
 
   def perform_comparison
-    env_dir = Horizon.config[:perform_comparison_workdir]
+    working_dir = Horizon.config[:working_dir]
 
-    if env_dir
-      Dir.mkdir(env_dir) unless Dir.exist?(env_dir)
-      perform_comparison_in_dir(env_dir)
+    if working_dir
+      Dir.mkdir(working_dir) unless Dir.exist?(working_dir)
+      perform_comparison_in_dir(working_dir)
     else
       Dir.mktmpdir(['releasecop', project.name]) do |dir|
         perform_comparison_in_dir(dir)
@@ -67,11 +67,11 @@ class ReleasecopService
     }
   end
 
-  def perform_comparison_in_dir(dir)
+  def perform_comparison_in_dir(working_dir)
     checker = Releasecop::Checker.new(
       project.name,
       project.stages.order(position: :asc).map { |s| build_manifest_item(s) },
-      dir
+      working_dir
     )
     ResultWrapper.new(checker) # build comparisons
   end

--- a/app/services/releasecop_service.rb
+++ b/app/services/releasecop_service.rb
@@ -19,6 +19,7 @@ class ReleasecopService
     env_dir = Horizon.config[:perform_comparison_workdir]
 
     if env_dir
+      Dir.mkdir(env_dir) unless Dir.exist?(env_dir)
       perform_comparison_in_dir(env_dir)
     else
       Dir.mktmpdir(['releasecop', project.name]) do |dir|

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -6,7 +6,8 @@ Horizon.config = {
   basic_auth_user: ENV['BASIC_AUTH_USER'] || 'admin',
   basic_auth_pass: ENV['BASIC_AUTH_PASS'],
   minimum_version_ruby: ENV['MINIMUM_VERSION_RUBY'],
-  minimum_version_node: ENV['MINIMUM_VERSION_NODE']
+  minimum_version_node: ENV['MINIMUM_VERSION_NODE'],
+  perform_comparison_workdir: ENV['PERFORM_COMPARISON_WORKDIR']
 }
 
 if Rails.env.production? # require certain config before booting in production

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -7,7 +7,7 @@ Horizon.config = {
   basic_auth_pass: ENV['BASIC_AUTH_PASS'],
   minimum_version_ruby: ENV['MINIMUM_VERSION_RUBY'],
   minimum_version_node: ENV['MINIMUM_VERSION_NODE'],
-  perform_comparison_workdir: ENV['PERFORM_COMPARISON_WORKDIR']
+  working_dir: ENV['WORKING_DIR']
 }
 
 if Rails.env.production? # require certain config before booting in production

--- a/spec/services/releasecop_service_spec.rb
+++ b/spec/services/releasecop_service_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec::Matchers.define :a_tmp_dir do
   match do |actual|
-    /.*releasecop.*/ =~ actual
+    actual =~ /.*releasecop.*/ # pattern used by ReleasecopService
   end
 end
 
@@ -18,20 +18,20 @@ RSpec.describe ReleasecopService, type: :service do
     end
   end
 
-  describe 'dir not set by user' do
-    it 'uses temp dir' do
+  describe 'working dir not set by user' do
+    it 'uses a temp dir' do
       obj = ReleasecopService.new(project)
       expect(obj).to receive(:perform_comparison_in_dir).with(a_tmp_dir)
       obj.perform_comparison
     end
   end
 
-  describe 'dir set by user' do
+  describe 'working dir set by user' do
     it 'uses user-specified dir' do
-      Dir.mktmpdir(['for_spec_only']) do |dir| # dir name must different from code
+      Dir.mktmpdir(['user_specified_dir']) do |dir| # using mktmpdir b/c it cleans up after
         allow(Horizon)
           .to receive(:config)
-          .and_return({ perform_comparison_workdir: dir })
+          .and_return({ working_dir: dir })
         obj = ReleasecopService.new(project)
         expect(obj).to receive(:perform_comparison_in_dir).with(dir)
         obj.perform_comparison

--- a/spec/services/releasecop_service_spec.rb
+++ b/spec/services/releasecop_service_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec::Matchers.define :a_tmp_dir do |expected|
+RSpec::Matchers.define :a_tmp_dir do
   match do |actual|
     /.*releasecop.*/ =~ actual
   end

--- a/spec/services/releasecop_service_spec.rb
+++ b/spec/services/releasecop_service_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ReleasecopService, type: :service do
       Dir.mktmpdir(['for_spec_only']) do |dir| # dir name must different from code
         allow(Horizon)
           .to receive(:config)
-          .and_return({perform_comparison_workdir: dir})
+          .and_return({ perform_comparison_workdir: dir })
         obj = ReleasecopService.new(project)
         expect(obj).to receive(:perform_comparison_in_dir).with(dir)
         obj.perform_comparison

--- a/spec/services/releasecop_service_spec.rb
+++ b/spec/services/releasecop_service_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec::Matchers.define :a_tmp_dir do |expected|
+  match do |actual|
+    /.*releasecop.*/ =~ actual
+  end
+end
+
+RSpec.describe ReleasecopService, type: :service do
+  include ActiveSupport::Testing::TimeHelpers
+  let(:org) { Organization.create! name: 'Artsy' }
+  let(:project) do
+    org.projects.create!(name: 'shipping').tap do |p|
+      p.stages.create!(name: 'master')
+      p.stages.create!(name: 'production')
+    end
+  end
+
+  describe 'dir not set by user' do
+    it 'uses temp dir' do
+      obj = ReleasecopService.new(project)
+      expect(obj).to receive(:perform_comparison_in_dir).with(a_tmp_dir)
+      obj.perform_comparison
+    end
+  end
+
+  describe 'dir set by user' do
+    it 'uses user-specified dir' do
+      Dir.mktmpdir(['for_spec_only']) do |dir| # dir name must different from code
+        allow(Horizon)
+          .to receive(:config)
+          .and_return({perform_comparison_workdir: dir})
+        obj = ReleasecopService.new(project)
+        expect(obj).to receive(:perform_comparison_in_dir).with(dir)
+        obj.perform_comparison
+      end
+    end
+  end
+end


### PR DESCRIPTION
Supports https://artsyproduct.atlassian.net/browse/PLATFORM-3487

`perform_comparison` currently instantiates `Releasecop::Checker` with a new temp dir every time. `Releasecop::Checker` clones the project-at-task into that temp dir. The effect is that [refresh comparisons cron](https://github.com/artsy/horizon/blob/7d12644694e49f8cec5dfc97cfba9ad4122cb94e/Rakefile#L12) which runs every 10min clones all projects afresh at every run.

This PR provides the option for `perform_comparison` to use a fixed dir specified by the user via ENV.

The plan is to persist projects' clones in an EBS volume which will be mounted to the cron's pod on that fixed dir at every run. Thus, the cron clones afresh on the first run, and on subsequent runs, it only fetches deltas.

I have confirmed locally that [releasecop's cloning a project](https://github.com/joeyAghion/releasecop/blob/bc9c108f1c4ff33fefe75ffb0c44f5ac8822594d/lib/releasecop/checker.rb#L13) does not error if the clone already exists.

Merging this PR should not change the cron's behavior. If everything is good, we can proceed with adding an EBS volume and setting the fixed dir ENV, likely in `hokusai/staging.yml` and `hokusai/production.yml`.