### PR TITLE
feat: refresh-comparisons cron persists git clones.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -152,6 +152,19 @@ spec:
               servicePort: http
 
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: horizon-refresh-comparisons-cron-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp2
+  resources:
+    requests:
+      storage: 10Gi
+
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -170,12 +183,22 @@ spec:
           containers:
             - name: horizon-refresh-comparisons-cron
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/horizon:production
-              args: ["bundle", "exec", "rake", "cron:refresh_comparisons"]
               imagePullPolicy: Always
+              args: ["bundle", "exec", "rake", "cron:refresh_comparisons"]
               envFrom:
                 - configMapRef:
                     name: horizon-environment
+              env:
+                - name: WORKING_DIR
+                  value: /home/deploy/data
           restartPolicy: Never
+          volumeMounts:
+            - name: data
+              mountPath: /home/deploy/data
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: horizon-refresh-comparisons-cron-data
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -151,6 +151,19 @@ spec:
               servicePort: http
 
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: horizon-refresh-comparisons-cron-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp2
+  resources:
+    requests:
+      storage: 10Gi
+
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -169,12 +182,22 @@ spec:
           containers:
             - name: horizon-refresh-comparisons-cron
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/horizon:staging
-              args: ["bundle", "exec", "rake", "cron:refresh_comparisons"]
               imagePullPolicy: Always
+              args: ["bundle", "exec", "rake", "cron:refresh_comparisons"]
               envFrom:
                 - configMapRef:
                     name: horizon-environment
+              env:
+                - name: WORKING_DIR
+                  value: /home/deploy/data
           restartPolicy: Never
+          volumeMounts:
+            - name: data
+              mountPath: /home/deploy/data
+          volumes:
+            - name: data
+              persistentVolumeClaim:
+                claimName: horizon-refresh-comparisons-cron-data
           affinity:
             nodeAffinity:
               requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Supports https://artsyproduct.atlassian.net/browse/PLATFORM-3487
Follows https://github.com/artsy/horizon/pull/423.

https://github.com/artsy/horizon/pull/423 allows us to pass a directory to [perform_comparison](https://github.com/artsy/horizon/blob/dc5efc984a7abdbe67af03e1abb8ab102af9c783/app/services/releasecop_service.rb#L18), by setting [WORKING_DIR](https://github.com/artsy/horizon/blob/dc5efc984a7abdbe67af03e1abb8ab102af9c783/config/initializers/_config.rb#L10) var, which would cause [Releasecop::Checker](https://github.com/artsy/horizon/blob/dc5efc984a7abdbe67af03e1abb8ab102af9c783/app/services/releasecop_service.rb#L71) to clone repos into a specific directory.

This PR sets that directory to `/home/deploy/data`. `perform_comparison` is only triggered by `horizon-refresh-comparisons-cron` so the var is set only for that cron.

To actually persist the data, this PR also creates an EBS volume and sets the cron to mount it on `/home/deploy/data`, at every run.

The first cron run will create `/home/deploy/data` dir and populate it with git clones. Subsequent runs will just update the clones with deltas from Github.

EBS volume size of 10 GB should be plenty to house the git repos for quite some time.
