### PR TITLE
fix: /home/deploy/data volume owner/group.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,10 @@ COPY --chown=deploy:deploy --from=builder /usr/local/bundle /usr/local/bundle
 RUN mkdir -p /shared/pids /shared/sockets && \
     chown -R deploy:deploy /shared
 
+# Create directories for cron.
+RUN mkdir /home/deploy/data && \
+    chown -R deploy:deploy /home/deploy/data
+
 # TODO: dump dev bundle
 RUN rm -rf node_modules
 

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -179,6 +179,18 @@ spec:
           annotations:
             "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
         spec:
+          initContainers:
+            - name: fix-the-volume-permission
+              image: busybox
+              command:
+              - sh
+              - -c
+              - chown -R 1001:1001 /home/deploy/data
+              securityContext:
+                privileged: true
+              volumeMounts:
+                - name: data
+                  mountPath: /home/deploy/data
           containers:
             - name: horizon-refresh-comparisons-cron
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/horizon:staging


### PR DESCRIPTION
Follows https://github.com/artsy/horizon/pull/426

Without the init container, volume is mounted as owned by `root` so that `deploy` user cannot write to it.

This PR is a work-around, not really a solution. If container user's UID changes, permission will break. I will do some research but it seems there's no Kubernetes solution.

Staging will be broken next time the comparisons cron runs. I've placed a Deploy Block. Once this is merged, Staging will be good and I will remove the Block.