### PR TITLE
feat: comparison cron, init container chown only if required.

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -184,9 +184,16 @@ spec:
             - name: fix-the-volume-permission
               image: busybox
               command:
-              - sh
+              - /bin/sh
               - -c
-              - chown -R 1001:1001 /home/deploy/data
+              - |
+                DEPLOY_USER_UID=1001
+                MOUNT_DIR=/home/deploy/data
+                MOUNT_DIR_UID=$(stat -c %u $MOUNT_DIR)
+                if [ "$MOUNT_DIR_UID" != "$DEPLOY_USER_UID" ]
+                then
+                  chown -R "$DEPLOY_USER_UID":"$DEPLOY_USER_UID" $MOUNT_DIR
+                fi
               securityContext:
                 privileged: true
               volumeMounts:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -183,9 +183,16 @@ spec:
             - name: fix-the-volume-permission
               image: busybox
               command:
-              - sh
+              - /bin/sh
               - -c
-              - chown -R 1001:1001 /home/deploy/data
+              - |
+                DEPLOY_USER_UID=1001
+                MOUNT_DIR=/home/deploy/data
+                MOUNT_DIR_UID=$(stat -c %u $MOUNT_DIR)
+                if [ "$MOUNT_DIR_UID" != "$DEPLOY_USER_UID" ]
+                then
+                  chown -R "$DEPLOY_USER_UID":"$DEPLOY_USER_UID" $MOUNT_DIR
+                fi
               securityContext:
                 privileged: true
               volumeMounts:


### PR DESCRIPTION
In https://github.com/artsy/horizon/pull/431, we added an `init` container to refresh-comparison cron, whose purpose was to `chown` the `/home/deploy/data` volume to `deploy` user, as otherwise the volume is mounted under `root` user. The `chown` is run every time the cron runs.

It looks like running every time is not required, that after the first `chown`, for subsequent runs, the volume is mounted under `deploy` user automatically. In this case, we should skip `chown` for subsequent runs, as the volume houses the clones of 50+ projects. `chown` on all their files is likely contributing to the bulk of the cron's runtime.

This PR modifies the init container so that it `chown`s only when the dir is NOT already owned by `deploy` user.

The cron already runs faster than before the volume was added (3min vs. 4-6min before). I expect that after this PR it will be even faster.

The shell logic is inline in k8s spec. If it feels unwieldy, I guess we can create our own `busybox` image with a script that does all that.
