### PR TITLE
feat: limit prod refresh comparison cron job to 10 minutes

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -175,6 +175,7 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 0
+      activeDeadlineSeconds: 600
       template:
         metadata:
           annotations:


### PR DESCRIPTION
Due to suspicion that sometimes a cron run hangs forever preventing subsequent runs.

https://artsy.slack.com/archives/CA8SANW3W/p1634163210004000