### PR TITLE
fea: add support for multiple slack webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The UI can then be found at http://localhost:3000.
   "base": "release",
   "head": "staging",
   "merge_after": 86400,
-  "slack_webhook_url":"https://hooks.slack.com/services/T.../B.../Q..., https://hooks.slack.com/services/O.../C.../U..."
+  "slack_webhook_url": ["https://hooks.slack.com/services/T.../B.../Q...", "https://hooks.slack.com/services/O.../C.../U..."]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The UI can then be found at http://localhost:3000.
   "base": "release",
   "head": "staging",
   "merge_after": 86400,
-  "slack_webhook_url":"https://hooks.slack.com/services/T.../B.../Q..."
+  "slack_webhook_url":"https://hooks.slack.com/services/T.../B.../Q..., https://hooks.slack.com/services/O.../C.../U..."
 }
 ```
 

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -81,7 +81,7 @@ class DeployService
   end
 
   def deliver_slack_webhook(pull_request, webhook_urls, merge_at)
-    webhook_urls.split(',').each { |webhook_url| send_slack_alert(pull_request, webhook_url.strip, merge_at) sleep 1 }
+    webhook_urls.split(',').each { |webhook_url| send_slack_alert(pull_request, webhook_url.strip, merge_at) }
   end
 
   def send_slack_alert(pull_request, webhook_url, merge_at)

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -95,7 +95,7 @@ class DeployService
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = (uri.scheme == 'https')
     http.request(request)
-  rescue
+  rescue StandardError => e
     Rails.logger.warn "Failed to deliver webhook to #{webhook_url.inspect} (#{e.message})"
   end
 

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -81,7 +81,7 @@ class DeployService
   end
 
   def deliver_slack_webhook(pull_request, webhook_urls, merge_at)
-    webhook_urls.split(',').each { |webhook_url| send_slack_alert(pull_request, webhook_url.strip, merge_at) }
+    webhook_urls.split(',').each { |webhook_url| send_slack_alert(pull_request, webhook_url.strip, merge_at) sleep 1 }
   end
 
   def send_slack_alert(pull_request, webhook_url, merge_at)

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -81,7 +81,7 @@ class DeployService
   end
 
   def deliver_slack_webhook(pull_request, webhook_urls, merge_at)
-    webhook_urls.split(',').each { |webhook_url| send_slack_alert(pull_request, webhook_url, merge_at) }
+    webhook_urls.split(',').each { |webhook_url| send_slack_alert(pull_request, webhook_url.strip, merge_at) }
   end
 
   def send_slack_alert(pull_request, webhook_url, merge_at)

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -80,7 +80,11 @@ class DeployService
       (raise 'A profile and basic_password are required for Github authentication')
   end
 
-  def deliver_slack_webhook(pull_request, webhook_url, merge_at)
+  def deliver_slack_webhook(pull_request, webhook_urls, merge_at)
+    webhook_urls.split(',').each { |webhook_url| send_slack_alert(pull_request, webhook_url, merge_at) }
+  end
+
+  def send_slack_alert(pull_request, webhook_url, merge_at)
     uri = URI.parse webhook_url
     request = Net::HTTP::Post.new(uri.request_uri)
     request['Content-Type'] = 'application/json'
@@ -91,7 +95,7 @@ class DeployService
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = (uri.scheme == 'https')
     http.request(request)
-  rescue StandardError => e
+  rescue
     Rails.logger.warn "Failed to deliver webhook to #{webhook_url.inspect} (#{e.message})"
   end
 

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -81,7 +81,7 @@ class DeployService
   end
 
   def deliver_slack_webhook(pull_request, webhook_urls, merge_at)
-    webhook_urls.split(',').each { |webhook_url| send_slack_alert(pull_request, webhook_url.strip, merge_at) }
+    webhook_urls.each { |webhook_url| send_slack_alert(pull_request, webhook_url.strip, merge_at) }
   end
 
   def send_slack_alert(pull_request, webhook_url, merge_at)

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -195,7 +195,7 @@ RSpec.feature 'Deploys', type: :feature do
       }.to_json,
       headers: { 'Content-Type' => 'application/json' }
     ).to_return(status: 201)
-    
+
     secondwebhook = stub_request(:post, strategy.arguments['slack_webhook_url'].second.strip).with(
       body: {
         text: 'The following changes will be released in about 1 hour: https://github.com/artsy/candela/pull/342'
@@ -208,6 +208,5 @@ RSpec.feature 'Deploys', type: :feature do
     DeployService.new(strategy).start
     expect(webhook).to have_been_made.once
     expect(secondwebhook).to have_been_made.once
-    
   end
 end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -152,7 +152,7 @@ RSpec.feature 'Deploys', type: :feature do
     strategy.update!(arguments: strategy.arguments.merge(
       merge_after: 26.hours.to_i,
       merge_prior_warning: 75.minutes.to_i,
-      slack_webhook_url: 'https://hooks.slack.com/services/foo/bar/baz, https://hooks.slack.com/services/bar/foo/cbzz'
+      slack_webhook_url: 'https://hooks.slack.com/services/foo/bar/baz'
     ))
     allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
       .with('artsy/candela', 'release', 'staging', anything, anything)

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -152,7 +152,7 @@ RSpec.feature 'Deploys', type: :feature do
     strategy.update!(arguments: strategy.arguments.merge(
       merge_after: 26.hours.to_i,
       merge_prior_warning: 75.minutes.to_i,
-      slack_webhook_url: 'https://hooks.slack.com/services/foo/bar/baz'
+      slack_webhook_url: 'https://hooks.slack.com/services/foo/bar/baz, https://hooks.slack.com/services/bar/foo/cbzz'
     ))
     allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
       .with('artsy/candela', 'release', 'staging', anything, anything)


### PR DESCRIPTION
We are introducing support for multiple slack channels notification by adding support for multiple webhooks in our release configuration.
More info [here](https://artsyproduct.atlassian.net/browse/PLATFORM-3682)

**This PR does:**
 - Add support for multiple slack webhooks for release notification:
 
**Requirements:**
Change deploy arguments from: 
```
{"base":"release","head":"staging","merge_after":86400,"slack_webhook_url":"https://hooks.slack.com/services/foo/bar/abc", "warned_pull_request_url":"https://github.com/anyrepo/pull/123"}
```
to:
```
{"base":"release","head":"staging","merge_after":86400,"slack_webhook_url": ["https://hooks.slack.com/services/foo/bar/abc"], "warned_pull_request_url":"https://github.com/anyrepo/pull/123"}
```
**Edge cases:**
If a configuration has a lot of different webhooks there is a possibility for been blocked by slack api rate limit, more info [here](https://api.slack.com/docs/rate-limits)
As a quick win we have decided to not assume a configuration with few webhooks.
