### PR TITLE
fea: Add blocked time period support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,3 +66,5 @@ end
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'webpacker', '~> 5.4'
+
+gem 'fugit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,6 +105,8 @@ GEM
     crass (1.0.6)
     diff-lcs (1.3)
     erubi (1.10.0)
+    et-orbi (1.2.6)
+      tzinfo
     execjs (2.7.0)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
@@ -112,6 +114,9 @@ GEM
     formtastic (4.0.0)
       actionpack (>= 5.2.0)
     formtastic_i18n (0.6.0)
+    fugit (1.5.2)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.4)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     has_scope (0.8.0)
@@ -172,6 +177,7 @@ GEM
     public_suffix (4.0.6)
     puma (4.3.9)
       nio4r (~> 2.0)
+    raabro (1.4.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-proxy (0.7.0)
@@ -316,6 +322,7 @@ DEPENDENCIES
   acts_as_list
   byebug
   capybara
+  fugit
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   octokit (~> 4.0)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ The UI can then be found at http://localhost:3000.
   "base": "release",
   "head": "staging",
   "merge_after": 86400,
-  "slack_webhook_url": ["https://hooks.slack.com/services/T.../B.../Q...", "https://hooks.slack.com/services/O.../C.../U..."]
+  "slack_webhook_url": ["https://hooks.slack.com/services/T.../B.../Q...", "https://hooks.slack.com/services/O.../C.../U..."],
+  "blocked_time_buckets": ["* 1-2 * * *"]
+
 }
 ```
 

--- a/app/admin/deploy_strategies.rb
+++ b/app/admin/deploy_strategies.rb
@@ -26,7 +26,8 @@ ActiveAdmin.register DeployStrategy do
       f.input :arguments_input,
               label: 'Arguments (JSON)',
               hint: 'Supported properties: base (branch), head (branch), repo (e.g., org/project), " +
-              "merge_after (sec.), merge_prior_warning (sec., default 3600) slack_webhook_url, warned_pull_request_url'
+              "merge_after (sec.), merge_prior_warning (sec., default 3600) slack_webhook_url, warned_pull_request_url
+              blocked_time_buckets'
     end
     f.actions
   end

--- a/app/models/deploy_strategy.rb
+++ b/app/models/deploy_strategy.rb
@@ -15,7 +15,8 @@ class DeployStrategy < ApplicationRecord
       'merge_after', # seconds after which to automatically merge release PRs (default 86400 or 24 hours)
       'merge_prior_warning', # when to notify slack about a pending merge, in seconds (default 3600 or 1 hour)
       'slack_webhook_url', # for notifying prior to merging release PRs
-      'warned_pull_request_url' # used internally to avoid repeat notifications
+      'warned_pull_request_url', # used internally to avoid repeat notifications
+      'blocked_time_buckets' # a list of cron expr that allows to block merge deploys into an specific part of the day
     ]
   }.freeze
 

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -121,12 +121,11 @@ class DeployService
       .detect { |l| github_client.check_assignee(github_repo, l) }
   end
 
-  def can_release_now?(blocked_buckets, reference_time)
-    return if !blocked_buckets || !reference_time
+  def can_release_now?(buckets, reference_time)
+    return if !buckets || !reference_time
 
     time_wa = reference_time.beginning_of_minute.strftime('%a, %d %b %Y %H:%M')
-    (raise "Merge time is blocked") 
-      if blocked_buckets.map { |blocked_bucket| cron_match(time_wa, blocked_bucket) }.reduce(:|)
+    buckets.map { |blocked_bucket| cron_match(time_wa, blocked_bucket) }.reduce(:|) || (raise 'Merge time blocked')
   end
 
   def cron_match?(reference_time, blocked_bucket)

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -125,6 +125,8 @@ class DeployService
     return if !buckets || buckets.empty? || !reference_time
 
     time_wa = reference_time.beginning_of_minute.strftime('%a, %d %b %Y %H:%M')
+    pp time_wa
+    pp buckets
     buckets.map { |blocked_bucket| cron_match?(time_wa, blocked_bucket) }.reduce(:|) || (raise 'Merge time blocked')
   end
 

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -21,6 +21,7 @@ class DeployService
   private
 
   def create_github_pull_request
+    can_release_now?(deploy_strategy.arguments['blocked_time_buckets'], Time.now)
     pull_request = github_client.create_pull_request(
       github_repo,
       deploy_strategy.arguments['base'],
@@ -48,7 +49,6 @@ class DeployService
           return
         end
       end
-      can_release_now?(deploy_strategy.arguments['blocked_time_buckets'], merge_at)
 
       warn_at = merge_at - deploy_strategy.arguments.fetch('merge_prior_warning', MERGE_PRIOR_WARNING)
       if Time.now > warn_at &&

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -122,11 +122,10 @@ class DeployService
   end
 
   def can_release_now?(buckets, reference_time)
+    buckets = Array(buckets)
     return if !buckets || buckets.empty? || !reference_time
 
     time_wa = reference_time.beginning_of_minute.strftime('%a, %d %b %Y %H:%M')
-    pp time_wa
-    pp buckets
     buckets.map { |blocked_bucket| cron_match?(time_wa, blocked_bucket) }.reduce(:|) || (raise 'Merge time blocked')
   end
 

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -21,7 +21,7 @@ class DeployService
   private
 
   def create_github_pull_request
-    if can_release_now?(deploy_strategy.arguments['blocked_time_buckets'] || [], Time.now)
+    if can_release_now?(deploy_strategy.arguments['blocked_time_buckets'] || [])
       pull_request = github_client.create_pull_request(
         github_repo,
         deploy_strategy.arguments['base'],
@@ -121,8 +121,7 @@ class DeployService
       .detect { |l| github_client.check_assignee(github_repo, l) }
   end
 
-  def can_release_now?(buckets, reference_time)
-    time_wa = reference_time.beginning_of_minute.strftime('%a, %d %b %Y %H:%M')
-    buckets.none? { |bucket| Fugit::Cron.parse(bucket).match?(time_wa) }
+  def can_release_now?(buckets, reference_time = Time.now)
+    buckets.none? { |bucket| Fugit::Cron.parse(bucket).match?(reference_time.beginning_of_minute) }
   end
 end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -323,15 +323,7 @@ RSpec.feature 'Deploys', type: :feature do
       merge_after: 26.hours.to_i,
       merge_prior_warning: 75.minutes.to_i
     ))
-    allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
-      .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_raise(Octokit::UnprocessableEntity)
-    allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
-      .with('artsy/candela', base: 'release', head: 'staging')
-      .and_return([assigned_github_pull_request])
-    expect_any_instance_of(Octokit::Client).not_to receive(:merge_pull_request)
-    expect do
-      DeployService.new(strategy).start
-    end.to raise_error('Merge time blocked')
+    expect_any_instance_of(Octokit::Client).not_to receive(:create_pull_request)
+    DeployService.new(strategy).start
   end
 end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -321,7 +321,7 @@ RSpec.feature 'Deploys', type: :feature do
     strategy.update!(arguments: strategy.arguments.merge(
       blocked_time_buckets: ['* 1-23 * * *'],
       merge_after: 26.hours.to_i,
-      merge_prior_warning: 75.minutes.to_i,
+      merge_prior_warning: 75.minutes.to_i
     ))
     allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
       .with('artsy/candela', 'release', 'staging', anything, anything)

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -319,7 +319,7 @@ RSpec.feature 'Deploys', type: :feature do
 
   it 'failed to release due blocked time' do
     strategy.update!(arguments: strategy.arguments.merge(
-      blocked_time_buckets: ['* 1-23 * * *'],
+      blocked_time_buckets: ['* 0-23 * * *'],
       merge_after: 26.hours.to_i,
       merge_prior_warning: 75.minutes.to_i
     ))


### PR DESCRIPTION
**Description:**
As part of our automation we want to make our automated Deploy PR process as much flexible and reliable as possible, so we are introducing a new attribute into release automation called blocked_time_buckets which accepts an array of cron expression strings which can refine our automation to not create deploy PR's which are configured to release on blocked timespans. 
More info [here](https://artsyproduct.atlassian.net/browse/PLATFORM-3683)

**Compatibility:**
This config is backwards compatible. 
This config can be enabled by add a new attribute `blocked_time_buckets` into release config json
e.g.
https://releases.artsy.net/admin/stages/26/deploy_strategies/20 -> ARGUMENTS
from:
```
{"base"=>"release", "head"=>"staging"}
```
to:
```
{"base"=>"release", "head"=>"staging", "blocked_time_buckets": ["* 1-6 * * *", "* 18-22 * * *"]}
```
The expected behavior is that automated PR's will be only created on the time which fits into 7-18 and 23-00 daily.