### PR TITLE
fea: Add future resolved_at support

### DIFF
--- a/app/models/deploy_block.rb
+++ b/app/models/deploy_block.rb
@@ -3,8 +3,8 @@
 class DeployBlock < ApplicationRecord
   belongs_to :project
 
-  scope :unresolved, -> { where(resolved_at: nil) }
-  scope :resolved, -> { where.not(resolved_at: nil) }
+  scope :unresolved, -> { where(resolved_at: nil).or(where('resolved_at >= ?', DateTime.current)) }
+  scope :resolved, -> { where.not(resolved_at: nil).and(where('resolved_at <= ?', DateTime.current)) }
 
   after_save :broadcast_updates
 

--- a/app/models/deploy_block.rb
+++ b/app/models/deploy_block.rb
@@ -4,7 +4,7 @@ class DeployBlock < ApplicationRecord
   belongs_to :project
 
   scope :unresolved, -> { where(resolved_at: nil).or(where('resolved_at >= ?', DateTime.current)) }
-  scope :resolved, -> { where.not(resolved_at: nil).and(where('resolved_at <= ?', DateTime.current)) }
+  scope :resolved, -> { where('resolved_at <= ?', DateTime.current) }
 
   after_save :broadcast_updates
 


### PR DESCRIPTION
**Long short:**
We have discovery by misusage that resolved_at field don't work for us when it's informed on the deploy blocker creation, It actually silently ignore the blocker.
**This PR does:**
So, we are introducing a check to be sure that when future timespan is informed, then we still consider it as not resolved. Also it introduces a possibility to pre-inform the time you want this blocker to expire, which also introduce a nice feature.
more info [here](https://artsyproduct.atlassian.net/browse/PLATFORM-3721)

**Backwards compatibility:**
This change is backwards compatible. If a timespan is not informed, than behavior is the same as before.