### PR TITLE
Reorganize deploy logic to check for existing pull requests before creating new ones

### DIFF
--- a/app/admin/deploy_strategies.rb
+++ b/app/admin/deploy_strategies.rb
@@ -25,8 +25,8 @@ ActiveAdmin.register DeployStrategy do
       f.input :automatic
       f.input :arguments_input,
               label: 'Arguments (JSON)',
-              hint: 'Supported properties: base (branch), head (branch), repo (e.g., org/project), " +
-              "merge_after (sec.), merge_prior_warning (sec., default 3600) slack_webhook_url, warned_pull_request_url
+              hint: 'Supported properties: base (branch), head (branch), repo (e.g., org/project), merge_after (sec.),
+              merge_prior_warning (sec., default 3600), slack_webhook_url, warned_pull_request_url,
               blocked_time_buckets'
     end
     f.actions

--- a/app/models/deploy_strategy.rb
+++ b/app/models/deploy_strategy.rb
@@ -32,6 +32,12 @@ class DeployStrategy < ApplicationRecord
     arguments['repo'] || [stage.project.organization.name, stage.project.name].join('/')
   end
 
+  def can_release?(at = Time.now)
+    arguments.fetch('blocked_time_buckets', []).none? do |bucket|
+      Fugit::Cron.parse(bucket).match?(at.beginning_of_minute)
+    end
+  end
+
   private
 
   def validate_arguments

--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -71,12 +71,9 @@ class ComparisonService
   private
 
   def warrants_deploy?(stage)
-    comparison = stage.project.snapshot.comparisons.detect do |c|
+    stage.project.snapshot.comparisons.any? do |c|
       c.behind_stage == stage
     end
-    return false unless comparison
-
-    true
   end
 
   def equivalent_snapshots?(snapshot, result)

--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -13,58 +13,62 @@ class DeployService
 
   def start
     case deploy_strategy.provider
-    when 'github pull request' then create_github_pull_request
+    when 'github pull request' then create_or_update_github_pull_request
     else raise NotImplementedError
     end
   end
 
   private
 
-  def create_github_pull_request
-    if can_release_now?(deploy_strategy.arguments['blocked_time_buckets'] || [])
-      pull_request = github_client.create_pull_request(
-        github_repo,
-        deploy_strategy.arguments['base'],
-        deploy_strategy.arguments['head'],
-        'Deploy',
-        'This is an automatically generated release PR!'
-      )
-      assignee = choose_assignee(pull_request)
-      github_client.add_assignees(github_repo, pull_request.number, assignee) if assignee
+  def create_or_update_github_pull_request
+    return unless deploy_strategy.can_release?
+
+    pull_request = find_pull_request || create_pull_request
+    assign_pull_request(pull_request) if pull_request.assignee.blank?
+    return unless deploy_strategy.arguments['merge_after']
+
+    merge_at = pull_request.created_at + deploy_strategy.arguments['merge_after'].seconds
+    warn_at = merge_at - deploy_strategy.arguments.fetch('merge_prior_warning', MERGE_PRIOR_WARNING)
+
+    if warn_at.past? &&
+       (webhook_urls = deploy_strategy.arguments['slack_webhook_url']) &&
+       deploy_strategy.arguments['warned_pull_request_url'] != pull_request.html_url
+      deliver_slack_webhooks(pull_request, webhook_urls, merge_at)
+      deploy_strategy.update!(
+        arguments: deploy_strategy.arguments.merge(warned_pull_request_url: pull_request.html_url)
+      ) # keep track of deploys already warned about
+      return
     end
-  rescue Octokit::UnprocessableEntity # release PR already exists
-    pull_request = github_client.pull_requests(
+
+    # must re-request pull request to get mergeable attribute
+    if merge_at.past? && github_client.pull_request(github_repo, pull_request.number).mergeable?
+      github_client.merge_pull_request(github_repo, pull_request.number)
+    end
+  rescue Octokit::UnprocessableEntity => e # release PR already exists
+    Rails.logger.warn "Failed to create or update pull request: #{e.message}"
+  end
+
+  def find_pull_request
+    github_client.pull_requests(
       github_repo,
       base: deploy_strategy.arguments['base'],
       head: deploy_strategy.arguments['head']
-    ).first || return
+    ).first
+  end
 
-    if (merge_after = deploy_strategy.arguments['merge_after'])
-      merge_at = pull_request.created_at + merge_after.seconds
-      if Time.now > merge_at # merge release PR automatically
-        # re-request individual PR so mergeable attribute is available
-        pull_request = github_client.pull_request(github_repo, pull_request.number)
-        if pull_request.mergeable?
-          github_client.merge_pull_request(github_repo, pull_request.number)
-          return
-        end
-      end
+  def create_pull_request
+    github_client.create_pull_request(
+      github_repo,
+      deploy_strategy.arguments['base'],
+      deploy_strategy.arguments['head'],
+      'Deploy',
+      'This is an automatically generated release PR!'
+    )
+  end
 
-      warn_at = merge_at - deploy_strategy.arguments.fetch('merge_prior_warning', MERGE_PRIOR_WARNING)
-      if Time.now > warn_at &&
-         (webhook_url = deploy_strategy.arguments['slack_webhook_url']) &&
-         deploy_strategy.arguments['warned_pull_request_url'] != pull_request.html_url
-        deliver_slack_webhook(pull_request, webhook_url, merge_at)
-        deploy_strategy.update!(
-          arguments: deploy_strategy.arguments.merge(warned_pull_request_url: pull_request.html_url)
-        )
-      end
-    end
-
-    if pull_request.assignee.blank? # try to assign if unassigned
-      assignee = choose_assignee(pull_request)
-      github_client.add_assignees(github_repo, pull_request.number, assignee) if assignee
-    end
+  def assign_pull_request(pull_request)
+    assignee = choose_assignee(pull_request)
+    github_client.add_assignees(github_repo, pull_request.number, assignee) if assignee
   end
 
   def github_client
@@ -89,8 +93,10 @@ class DeployService
     false
   end
 
-  def deliver_slack_webhook(pull_request, webhook_urls, merge_at)
-    Array(webhook_urls).each { |webhook_url| send_slack_alert(pull_request, webhook_url.strip, merge_at) }
+  def deliver_slack_webhooks(pull_request, webhook_urls, merge_at)
+    Array(webhook_urls).each do |webhook_url|
+      send_slack_alert(pull_request, webhook_url.strip, merge_at)
+    end
   rescue StandardError => e
     Rails.logger.warn "Failed to deliver webhook to #{webhook_urls.inspect} (#{e.message})"
   end
@@ -100,9 +106,9 @@ class DeployService
       uri = URI.parse webhook_url
       request = Net::HTTP::Post.new(uri.request_uri)
       request['Content-Type'] = 'application/json'
+      distance_of_time = merge_at.past? ? 'a few minutes' : distance_of_time_in_words_to_now(merge_at)
       request.body = {
-        text: "The following changes will be released in #{distance_of_time_in_words_to_now(merge_at)}: " +
-              pull_request.html_url
+        text: "The following changes will be released in #{distance_of_time}: #{pull_request.html_url}"
       }.to_json
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = (uri.scheme == 'https')
@@ -119,9 +125,5 @@ class DeployService
       .reject { |c| c.nil? || c.type == 'Bot' || c.login == 'web-flow' || c.login == 'artsyit' || c.login[/\bbot\b/] }
       .group_by(&:login).map { |k, v| [v.size, k] }.sort.reverse.map(&:last)
       .detect { |l| github_client.check_assignee(github_repo, l) }
-  end
-
-  def can_release_now?(buckets, reference_time = Time.now)
-    buckets.none? { |bucket| Fugit::Cron.parse(bucket).match?(reference_time.beginning_of_minute) }
   end
 end

--- a/spec/features/deploy_spec.rb
+++ b/spec/features/deploy_spec.rb
@@ -55,6 +55,9 @@ RSpec.feature 'Deploys', type: :feature do
   end
 
   it 'sends an Octokit request to create pull request' do
+    allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
+      .with('artsy/candela', base: 'release', head: 'staging')
+      .and_return([])
     expect_any_instance_of(Octokit::Client).to receive(:create_pull_request)
       .with('artsy/candela', 'release', 'staging', anything, anything)
       .and_return(github_pull_request)
@@ -63,6 +66,9 @@ RSpec.feature 'Deploys', type: :feature do
   end
 
   it 'assigns deploy pull request to appropriate user' do
+    allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
+      .with('artsy/candela', base: 'release', head: 'staging')
+      .and_return([])
     expect_any_instance_of(Octokit::Client).to receive(:create_pull_request)
       .with('artsy/candela', 'release', 'staging', anything, anything)
       .and_return(github_pull_request)
@@ -80,6 +86,9 @@ RSpec.feature 'Deploys', type: :feature do
   end
 
   it 'handles unsigned commits' do
+    allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
+      .with('artsy/candela', base: 'release', head: 'staging')
+      .and_return([])
     expect_any_instance_of(Octokit::Client).to receive(:create_pull_request)
       .with('artsy/candela', 'release', 'staging', anything, anything)
       .and_return(github_pull_request)
@@ -95,9 +104,6 @@ RSpec.feature 'Deploys', type: :feature do
   end
 
   it 'adds assignees to existing deploy PRs when unassigned' do
-    expect_any_instance_of(Octokit::Client).to receive(:create_pull_request)
-      .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_raise(Octokit::UnprocessableEntity)
     allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
       .with('artsy/candela', base: 'release', head: 'staging')
       .and_return([github_pull_request])
@@ -117,9 +123,6 @@ RSpec.feature 'Deploys', type: :feature do
 
   it 'merges release PR after designated period of time' do
     strategy.update!(arguments: strategy.arguments.merge(merge_after: 24.hours.to_i))
-    expect_any_instance_of(Octokit::Client).to receive(:create_pull_request)
-      .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_raise(Octokit::UnprocessableEntity)
     allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
       .with('artsy/candela', base: 'release', head: 'staging')
       .and_return([assigned_github_pull_request])
@@ -133,9 +136,6 @@ RSpec.feature 'Deploys', type: :feature do
 
   it 'does not attempt to merge unmergeable PRs' do
     strategy.update!(arguments: strategy.arguments.merge(merge_after: 24.hours.to_i))
-    expect_any_instance_of(Octokit::Client).to receive(:create_pull_request)
-      .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_raise(Octokit::UnprocessableEntity)
     allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
       .with('artsy/candela', base: 'release', head: 'staging')
       .and_return([assigned_github_pull_request])
@@ -154,9 +154,6 @@ RSpec.feature 'Deploys', type: :feature do
       merge_prior_warning: 75.minutes.to_i,
       slack_webhook_url: ['https://hooks.slack.com/services/foo/bar/baz']
     ))
-    allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
-      .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_raise(Octokit::UnprocessableEntity)
     allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
       .with('artsy/candela', base: 'release', head: 'staging')
       .and_return([assigned_github_pull_request])
@@ -181,9 +178,6 @@ RSpec.feature 'Deploys', type: :feature do
       merge_prior_warning: 75.minutes.to_i,
       slack_webhook_url: 'https://hooks.slack.com/services/foo/bar/baz'
     ))
-    allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
-      .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_raise(Octokit::UnprocessableEntity)
     allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
       .with('artsy/candela', base: 'release', head: 'staging')
       .and_return([assigned_github_pull_request])
@@ -207,9 +201,6 @@ RSpec.feature 'Deploys', type: :feature do
       merge_prior_warning: 75.minutes.to_i,
       slack_webhook_url: ['https://hooks.slack.com/services/foo/bar/baz', 'https://hooks.slack.com/services/foo/bar/azb']
     ))
-    allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
-      .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_raise(Octokit::UnprocessableEntity)
     allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
       .with('artsy/candela', base: 'release', head: 'staging')
       .and_return([assigned_github_pull_request])
@@ -242,9 +233,6 @@ RSpec.feature 'Deploys', type: :feature do
       merge_prior_warning: 75.minutes.to_i,
       slack_webhook_url: 100
     ))
-    allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
-      .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_raise(Octokit::UnprocessableEntity)
     allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
       .with('artsy/candela', base: 'release', head: 'staging')
       .and_return([assigned_github_pull_request])
@@ -268,9 +256,6 @@ RSpec.feature 'Deploys', type: :feature do
       merge_prior_warning: 75.minutes.to_i,
       slack_webhook_url: ['http://hooks.slack.com/services/foo/bar/baz']
     ))
-    allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
-      .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_raise(Octokit::UnprocessableEntity)
     allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
       .with('artsy/candela', base: 'release', head: 'staging')
       .and_return([assigned_github_pull_request])
@@ -296,9 +281,6 @@ RSpec.feature 'Deploys', type: :feature do
       slack_webhook_url: ['invalidstring'],
       blocked_time_buckets: []
     ))
-    allow_any_instance_of(Octokit::Client).to receive(:create_pull_request)
-      .with('artsy/candela', 'release', 'staging', anything, anything)
-      .and_raise(Octokit::UnprocessableEntity)
     allow_any_instance_of(Octokit::Client).to receive(:pull_requests)
       .with('artsy/candela', base: 'release', head: 'staging')
       .and_return([assigned_github_pull_request])


### PR DESCRIPTION
Horizon's crons frequently fail on Github rate-limiting errors:

```
POST https://api.github.com/repos/artsy/<repo>/pulls: 403 - You have exceeded a secondary rate limit and have been temporarily blocked from content creation.
```

The same rate-limits have been plaguing Metaphysics' build steps that push its schema changes to other repositories ([e.g.](https://app.circleci.com/pipelines/github/artsy/metaphysics/10038/workflows/99f31c7c-1ccc-4fce-8653-9569a28c2a7a/jobs/20402)).

Until now, the cron always tried to create a deploy PR, relying on the `Octokit::UnprocessableEntity` error to indicate that a similar PR is already open. That was a little lazy of us. This PR updates the logic to first retrieve an existing deploy PR, then create one only if it doesn't.

The method was also getting very complex, so I extracted a few helper methods and it's hopefully easier to read and understand now.