### PR TITLE
Only attempt to create PRs when diffs are non-empty

### DIFF
--- a/app/models/comparison.rb
+++ b/app/models/comparison.rb
@@ -7,6 +7,8 @@ class Comparison < ApplicationRecord
 
   acts_as_list scope: :snapshot
 
+  scope :released, ->(released = true) { where(released: released) }
+
   def comparison_size
     description.length
   end

--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -71,7 +71,7 @@ class ComparisonService
   private
 
   def warrants_deploy?(stage)
-    stage.project.snapshot.comparisons.any? do |c|
+    stage.project.snapshot.comparisons.released(false).any? do |c|
       c.behind_stage == stage
     end
   end


### PR DESCRIPTION
I noticed log messages like the following after yesterday's refactor (https://github.com/artsy/horizon/pull/456):

```
Failed to create or update pull request: POST https://api.github.com/repos/artsy/diffusion/pulls: 422 - Validation Failed
Error summary:
  resource: PullRequest
  field: head
  code: invalid // See: https://docs.github.com/rest/reference/pulls#create-a-pull-request
```

It turns out there was a pre-existing bug in the `warrants_deploy?` helper that would invoke the `DeployService` when there was _any_ `Comparison` object associated with the deployable stage (e.g., production). Since a comparison can be empty, indicating there's no diff between stages, this PR updates the logic to only act on a diff. The old code attempted the PR creation, tried to find the PR if that failed, and then [just returned](https://github.com/artsy/horizon/pull/456/files#diff-b2fa015539d9967b0e4358c15fef7a77c9d7321acf8ca66d6cd21e4ccedb212aL40) if that failed. The new code logs the error, which made this more obvious.

(This bug probably aggravated our Github rate-limiting problem significantly.)