### PR TITLE
Create or update release PRs even during blocked time periods

### DIFF
--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -21,11 +21,9 @@ class DeployService
   private
 
   def create_or_update_github_pull_request
-    return unless deploy_strategy.can_release?
-
     pull_request = find_pull_request || create_pull_request
     assign_pull_request(pull_request) if pull_request.assignee.blank?
-    return unless deploy_strategy.arguments['merge_after']
+    return unless deploy_strategy.arguments['merge_after'] && deploy_strategy.can_release?
 
     merge_at = pull_request.created_at + deploy_strategy.arguments['merge_after'].seconds
     warn_at = merge_at - deploy_strategy.arguments.fetch('merge_prior_warning', MERGE_PRIOR_WARNING)


### PR DESCRIPTION
As [discussed](https://artsy.slack.com/archives/CA8SANW3W/p1637255685324700):

> Currently, all automated release PR actions (creating, assigning, auto-merging) respect the blocked time windows. This isn't a perfect fit for teams' workflows, because engineers reasonably want to deploy during the first half of the EU day or the 2nd half of the US day (or even :gasp: outside of those). Currently, no deploy PR will be available during the blocked times.
>
> I propose that we loosen this constraint so that creating and assigning deploy PRs happen whenever, so that engineers always have the option to deploy manually (by merging). Automatic merges should respect the blocked time windows, which can be configured for critical systems around "core" overlapping hours (US AM/EU PM). Release builds should continue to short-circuit when a deploy block exists.

This PR updates Horizon to create the deploy PR even during a blocked period (as long as there isn't an active deploy block). That way, engineers can continue to merge them at their convenience, while automatic merges also kick in during common weekday working hours.

We settled on suggesting this configuration for projects that want to limit automatic releases in this way, corresponding to 8a-12p EST or 2-6p CET:

```
"blocked_time_buckets":["* 0-12,17-23 * * 1-5", "* * * * 6-7"]
```

(Note for later: it's confusing that these are called "blocked" like deploy blocks. It might be simpler to switch to "allowed" times, which would usually just contain one string like `* 13-16 * * 1-5`.)