### PR TITLE
Avoid warning when eventual merge will encounter a blocked time

### DIFF
--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -30,7 +30,8 @@ class DeployService
 
     if warn_at.past? &&
        (webhook_urls = deploy_strategy.arguments['slack_webhook_url']) &&
-       deploy_strategy.arguments['warned_pull_request_url'] != pull_request.html_url
+       deploy_strategy.arguments['warned_pull_request_url'] != pull_request.html_url &&
+       (merge_at.past? || deploy_strategy.can_release?(merge_at))
       deliver_slack_webhooks(pull_request, webhook_urls, merge_at)
       deploy_strategy.update!(
         arguments: deploy_strategy.arguments.merge(warned_pull_request_url: pull_request.html_url)


### PR DESCRIPTION
I noticed a possible logic bug: Horizon warns before deploying even if the scheduled deploy will end up being blocked by `blocked_time_buckets`. This PR adds an additional check to _only_ warn if the calculated merge time isn't blocked.