### PR TITLE
Log debug statements around git operations, for easier debugging

### DIFF
--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -37,6 +37,7 @@ class ComparisonService
   end
 
   def self.refresh_comparisons_for_organization(org)
+    Rails.logger.debug "Refreshing comparisons for org ##{org.id}"
     new_snapshots = []
     org.projects.each do |project|
       new_snapshots << new(project).refresh_comparisons
@@ -49,6 +50,7 @@ class ComparisonService
   end
 
   def refresh_comparisons
+    Rails.logger.debug "Refreshing comparisons for project ##{project.id}"
     refreshed_at = Time.now
     result = ReleasecopService.new(project).perform_comparison
     new_snapshot = nil


### PR DESCRIPTION
After [last week's many branch renames](https://github.com/artsy/README/issues/427), I checked on Horizon's cron and saw messages like this indicating that several projects' configurations were broken:

```
fatal: ambiguous argument '369fbf0245b91941b7685b69c937fb37d1b8243a..main/master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [...] -- [...]'
fatal: ambiguous argument 'f588c0f4cfb410faf3e028a46f759c20fb3d3a36..main/master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [...] -- [...]'
fatal: ambiguous argument 'ee99b953b67e9a4caadeaa39a03062e9d8312384..main/master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [...] -- [...]'
fatal: ambiguous argument '04a9f7fd503267c99e8788a4733b189f6bf7113f..main/master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [...] -- [...]'
```

However, I couldn't easily tell _which_ projects were responsible for the errors. This PR adds debug-level log statements around each project refreshed by the recurring cron. By setting the `LOG_LEVEL=0` environment variable, we should be able to more easily diagnose issues based on cron logs in the future. (I recommend unsetting it afterwards.)