### PR TITLE
chore: remove artsy node orb from project_data_service

### DIFF
--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -43,7 +43,6 @@ class ProjectDataService
     orbs = []
     @circle_config.include?('artsy/auto@') && orbs.push('auto')
     @circle_config.include?('artsy/hokusai@') && orbs.push('hokusai')
-    @circle_config.include?('artsy/node@') && orbs.push('node')
     @circle_config.include?('artsy/release@') && orbs.push('release')
     @circle_config.include?('artsy/remote-docker@') && orbs.push('remote-docker')
     @circle_config.include?('artsy/yarn@') && orbs.push('yarn')


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4129

We decided to deprecate `artsy/node` orb. Because this orb is no longer used (directly) [across any of our active projects](https://github.com/search?q=org%3Aartsy+artsy%2Fnode&type=Code), this removes it from `project_data_service`.

