### PR TITLE
feat: delete deploy blocks on project deletion

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -8,7 +8,7 @@ class Project < ApplicationRecord
   belongs_to :organization
   has_many :stages, dependent: :destroy
   has_many :snapshots, dependent: :destroy
-  has_many :deploy_blocks
+  has_many :deploy_blocks, dependent: :destroy
   belongs_to :snapshot, optional: true
   has_many :dependencies, dependent: :destroy
 

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Project, type: :model do
 
   it 'can be deleted despite associations' do
     snapshot = project.snapshots.create!
+    project.deploy_blocks.create!
     snapshot.comparisons.create!(ahead_stage: project.stages.first, behind_stage: project.stages.last)
     project.update(snapshot: snapshot)
     expect(project.destroy).to be_present


### PR DESCRIPTION
While deprecating KAWS and following [this checklist](https://www.notion.so/artsy/Retiring-KAWS-97f3a26e5e1e4141a3d38b030e00ca48), we came to the step where we were supposed to delete the project from Horizon and discovered we couldn't since it still had associated deploy_blocks and there was a foreign key constraint on them. This PR makes sure that we delete deploy blocks before deleting projects!