### PR TITLE
POC - Rails - standard logging format

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'activeadmin' # manage models
 gem 'active_admin_datetimepicker'
 gem 'acts_as_list' # order Project#stages
+gem 'lograge'
 gem 'octokit', '~> 4.0' # talk to github api
 gem 'redis' # actioncable adapter
 gem 'releasecop', '>= 0.0.15' # compare release stages

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.12.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -226,6 +231,8 @@ GEM
     regexp_parser (2.5.0)
     releasecop (0.0.16)
       thor
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -326,6 +333,7 @@ DEPENDENCIES
   fugit
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  lograge
   octokit (~> 4.0)
   pg (>= 0.18, < 2.0)
   puma (~> 4.3)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,7 +63,6 @@ Rails.application.configure do
 
   if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -52,9 +52,6 @@ Rails.application.configure do
   # when problems arise.
   config.log_level = :info
 
-  # Prepend all log lines with the following tags.
-  config.log_tags = [:request_id]
-
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store
 
@@ -75,16 +72,12 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.lograge.enabled = true
+  config.lograge.formatter = Lograge::Formatters::Json.new
+  config.lograge.custom_options = lambda do |event|
+    {
+      request_id: event.payload[:headers]['action_dispatch.request_id']
+    }.compact
+  end
+end


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4904

This PR introduces a new logger [lograge](https://github.com/roidrage/lograge) (replacing default rails logger) for the purposes of proving out a POC which is about _standardizing logging posture across Artsy applications_ and specifically as it pertains to web apps.

<details>
<summary>The following options have been evaluated before moving forward with lograge</summary>

#### Default Rails logger
> Using the default logger and switching to JSON is relatively straightforward however the required level of customization as far as which events to log and then structuring the output to fit Artsy needs is nontrivial. Given that [a couple of Artsy projects already use _lograge_](https://github.com/search?q=org%3Aartsy+lograge&type=code) it doesn't seem worth spending time on building a homegrown structured logging module for rails apps.

#### [logstasher](https://github.com/shadabahmed/logstasher)
> This solution comes with [logstash](https://www.elastic.co/logstash/) and [Kibana](http://kibana.org/) and is specifically designed to output logs in _logstash_ compatible format. This may be the top candidate if the goal was to evaluate an alternative log management/aggregation solution (an alternative to _papertrail_). Seeing as this effort is about standardizing the logging structure this solution does not seem ideal with how much else it adds.

#### [logist](https://github.com/h3poteto/logist)
> _Tiny_ JSON based structured logging gem for rails. At first it seemed like a good choice however documentation is very minimal (compaed to _lograge_) and it uses [_lograge_ formatter](https://github.com/h3poteto/logist/blob/162f2bc6576663ecec90b5384608fe277d5fe400/lib/logist/railtie.rb#L6) under the hood. Adoption seems minimal and that the gem hasn't been updated since 2020 so pass on this and use _lograge_ directly instead.

</details>

Choosing _lograge_ seemed like a no-brainer seeing as we already import this gem in [a couple of projects](https://github.com/search?q=org%3Aartsy+lograge&type=code) and among alternatives: this gem is quite popular, well documented and still maintained.

### default logger vs lograge

> examples pulled from production mode

```ruby
# default
I, [2023-02-08T10:53:34.520694 #12855]  INFO -- : [27a4c934-f255-4336-ab11-205323e6c4b3] Started GET "/admin/projects" for 127.0.0.1 at 2023-02-08 10:53:34 -0500
I, [2023-02-08T10:53:34.521270 #12855]  INFO -- : [27a4c934-f255-4336-ab11-205323e6c4b3] Processing by Admin::ProjectsController#index as HTML
I, [2023-02-08T10:53:34.575644 #12855]  INFO -- : [27a4c934-f255-4336-ab11-205323e6c4b3]   Rendered /Users/[REDACTED]/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activeadmin-2.13.1/app/views/active_admin/resource/index.html.arb (Duration: 40.0ms | Allocations: 32988)
I, [2023-02-08T10:53:34.575858 #12855]  INFO -- : [27a4c934-f255-4336-ab11-205323e6c4b3] Completed 200 OK in 55ms (Views: 38.6ms | ActiveRecord: 1.9ms | Allocations: 33562)
I, [2023-02-08T10:53:51.645002 #12855]  INFO -- : [7f51bc38-d881-4534-b361-5e5f9d0ffcf5] Started GET "/admin/profiles" for 127.0.0.1 at 2023-02-08 10:53:51 -0500
I, [2023-02-08T10:53:51.646074 #12855]  INFO -- : [7f51bc38-d881-4534-b361-5e5f9d0ffcf5] Processing by Admin::ProfilesController#index as HTML
I, [2023-02-08T10:53:51.692986 #12855]  INFO -- : [7f51bc38-d881-4534-b361-5e5f9d0ffcf5]   Rendered /Users/[REDACTED]/.rbenv/versions/2.6.6/lib/ruby/gems/2.6.0/gems/activeadmin-2.13.1/app/views/active_admin/resource/index.html.arb (Duration: 43.9ms | Allocations: 20232)
I, [2023-02-08T10:53:51.693229 #12855]  INFO -- : [7f51bc38-d881-4534-b361-5e5f9d0ffcf5] Completed 200 OK in 47ms (Views: 27.9ms | ActiveRecord: 17.7ms | Allocations: 21467
```


```ruby
# lograge
{"method":"GET","path":"/admin/projects","format":"html","controller":"Admin::ProjectsController","action":"index","status":200,"duration":179.93,"view":95.29,"db":67.61,"request_id":"f8608a30-9c42-4e6a-aef5-8a47939ac96f"}
{"method":"GET","path":"/admin/profiles","format":"html","controller":"Admin::ProfilesController","action":"index","status":200,"duration":78.56,"view":42.72,"db":23.14,"request_id":"2fe21357-0924-4045-821a-9b474f654791"}
```

Logs when running in `development` are very similar with the main exception being that query execution is being logged, example:
```ruby
  Organization Load (0.3ms)  SELECT "organizations".* FROM "organizations"
  Stage Load (0.3ms)  SELECT "stages".* FROM "stages"
  Snapshot Load (0.2ms)  SELECT "snapshots".* FROM "snapshots"
  DeployBlock Load (0.3ms)  SELECT "deploy_blocks".* FROM "deploy_blocks"
  CACHE Snapshot Load (0.0ms)  SELECT "snapshots".* FROM "snapshots"
  Dependency Load (0.2ms)  SELECT "dependencies".* FROM "dependencies"
```

> ☝️ log lines didn't change upon integrating _lograge_.

The above example of _lograge logs_ demonstrates what can be achived with _minimal configuration_, what is proposed in this PR. By leveraging `custom_options` we can expand the structure with additional information:

```
# environment config (not complete example)
config.lograge.custom_options = lambda do |event|
  {
    level: event.payload[:level],
    request_time: Time.now,
    process_id: Process.pid,
    host: event.payload[:host],
    port: event.payload[:port],
    ip: event.payload[:ip],
    params: event.payload[:params].except(:action, :controller).to_json,
    rails_env: Rails.env,
    remote_ip: event.payload[:remote_ip],
    request_id: event.payload[:headers]['action_dispatch.request_id'],
  }.compact
end
```

```ruby
# customized lograge log
{"method":"GET","path":"/admin/projects","format":"html","controller":"Admin::ProjectsController","action":"index","status":200,"duration":3997.62,"view":3915.53,"db":63.8,"level":"INFO","request_time":"2023-02-07 16:53:31 -0500","process_id":95945,"host":"localhost","port":3000,"ip":"::1","params":"{}","rails_env":"development","remote_ip":"::1","request_id":"4ff642fb-277a-4281-b7f3-b238707fe78f"}
```

### What about background workers?

_Lograge is a rails logger_. Integrating this gem does not automatically cover background worker logging and the docs do not mention anything about this topic. I have not yet found a solution for structured logging as far as `sneakers` and `sidekiq/activejob` workers however I am evaluating the https://github.com/tilfin/ougai, which I came across most recently.