### PR TITLE
feat: use safe navigation when accessing request_id in lograge custom_options

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   config.lograge.formatter = Lograge::Formatters::Json.new
   config.lograge.custom_options = lambda do |event|
     {
-      request_id: event.payload[:headers]['action_dispatch.request_id']
+      request_id: event.payload[:headers]&.[]('action_dispatch.request_id')
     }.compact
   end
 end


### PR DESCRIPTION
Followup to https://github.com/artsy/horizon/pull/558

Add safe navigation when setting `request_id` in lograge `custom_options`. This prevents `action_cable` errors observed when accessing the `/` route.

```
Could not log "connect.action_cable" event. NoMethodError: undefined method `[]' for nil:NilClass
...
```