### PR TITLE
fix: failing ruby upgrade because of keyword argument syntax change

### DIFF
--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -45,7 +45,7 @@ class ComparisonService
       Rails.logger.error "Refreshing project ##{project.id} (#{project.name}) failed with: #{e.full_message}"
     end
     new_snapshots.compact!
-    ActionCable.server.broadcast(ProjectChannel.channel_name(org.id), newSnapshots: true) if new_snapshots.any?
+    ActionCable.server.broadcast(ProjectChannel.channel_name(org.id), { newSnapshots: true }) if new_snapshots.any?
     new_snapshots
   end
 

--- a/app/services/comparison_service.rb
+++ b/app/services/comparison_service.rb
@@ -15,7 +15,7 @@ class ComparisonService
     Organization.all.map do |org|
       new_snapshots += refresh_comparisons_for_organization(org)
     end
-    ActionCable.server.broadcast(ProjectChannel.channel_name, newSnapshots: true) if new_snapshots.any?
+    ActionCable.server.broadcast(ProjectChannel.channel_name, { newSnapshots: true }) if new_snapshots.any?
     new_snapshots
   end
 

--- a/spec/services/comparison_service_spec.rb
+++ b/spec/services/comparison_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe ComparisonService, type: :model do
   include ActiveSupport::Testing::TimeHelpers
   let(:org) { Organization.create! name: 'Artsy' }
-  let(:project) do
+  let!(:project) do
     org.projects.create!(name: 'shipping').tap do |p|
       p.stages.create!(name: 'main')
       p.stages.create!(name: 'production')
@@ -14,9 +14,15 @@ RSpec.describe ComparisonService, type: :model do
 
   describe 'refresh_all_comparisons' do
     it 'recovers from releasecop comparison failures' do
-      project # ensure project and org are created
-      allow_any_instance_of(ComparisonService).to receive(:refresh_comparisons).and_raise(ZeroDivisionError)
+      allow_any_instance_of(ComparisonService).to receive(:refresh_comparisons)
+        .and_raise(ZeroDivisionError)
       expect { ComparisonService.refresh_all_comparisons }.not_to raise_error
+    end
+  end
+
+  describe 'refresh_comparisons_for_organizations' do
+    it 'works' do
+      expect { ComparisonService.refresh_comparisons_for_organization(org) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
An untested service failed with the new ruby version. More info here: https://artsy.slack.com/archives/CA8SANW3W/p1675958384294309

This is a fix
To-Do: write another test for the comparison service.