### PR TITLE
feat: extend basic authentication to API (PLATFORM-4840)

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Api
+  class BaseController < ApplicationController
+    before_action :admin_basic_auth
+  end
+end

--- a/app/controllers/api/deploy_blocks_controller.rb
+++ b/app/controllers/api/deploy_blocks_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Api
-  class DeployBlocksController < ApplicationController
+  class DeployBlocksController < Api::BaseController
     def index
       project = Project.find(params[:project_id])
       coerced_resolved_param =


### PR DESCRIPTION
The API for retrieving unresolved deploy blocks is currently open to the internet. The application [already enforces basic authentication](https://github.com/artsy/horizon/blob/04a9f7fd503267c99e8788a4733b189f6bf7113f/config/initializers/active_admin.rb#L174) for its admin UI (but not for its dashboard), those credentials are already supplied by [the orb](https://github.com/artsy/orbs/blob/24cb25c499a72ce0953faa75c024462a58fc7a9f/src/release/release.yml#L25), and [all uses of the orb](https://github.com/search?p=1&q=org%3Aartsy+%22horizon%3Ablock%22&type=Code) employ the `horizon` context containing the credential values.

I.e., I think this should just work. Of course, it might not, so I should monitor a deploy or 2 once this is released.

https://artsyproduct.atlassian.net/browse/PLATFORM-4840