### PR TITLE
chore: add DogStatsD

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby File.read('.ruby-version')
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'coffee-rails'
+gem 'dogstatsd-ruby', require: 'datadog/statsd' # send metrics to datadog agent
 gem 'rails', '~> 6.1.6.1'
 # Use postgresql as the database for Active Record
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,7 @@ GEM
       rexml
     crass (1.0.6)
     diff-lcs (1.5.0)
+    dogstatsd-ruby (5.5.0)
     erubi (1.10.0)
     et-orbi (1.2.7)
       tzinfo
@@ -328,6 +329,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails
+  dogstatsd-ruby
   fugit
   jbuilder (~> 2.5)
   listen

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -9,7 +9,7 @@ Horizon.config = {
   minimum_version_node: ENV.fetch('MINIMUM_VERSION_NODE', nil),
   working_dir: ENV.fetch('WORKING_DIR', nil),
   datadog_service_name: ENV['DATADOG_SERVICE_NAME'] || 'horizon',
-  datadog_trace_agent_hostname: ENV.fetch('DATADOG_TRACE_AGENT_HOSTNAME', 'datadog')
+  datadog_trace_agent_hostname: ENV.fetch('DATADOG_TRACE_AGENT_HOSTNAME', nil)
 }
 
 if Rails.env.production? && Horizon.config[:basic_auth_pass].blank?

--- a/config/initializers/_config.rb
+++ b/config/initializers/_config.rb
@@ -7,7 +7,9 @@ Horizon.config = {
   basic_auth_pass: ENV.fetch('BASIC_AUTH_PASS', nil),
   minimum_version_ruby: ENV.fetch('MINIMUM_VERSION_RUBY', nil),
   minimum_version_node: ENV.fetch('MINIMUM_VERSION_NODE', nil),
-  working_dir: ENV.fetch('WORKING_DIR', nil)
+  working_dir: ENV.fetch('WORKING_DIR', nil),
+  datadog_service_name: ENV['DATADOG_SERVICE_NAME'] || 'horizon',
+  datadog_trace_agent_hostname: ENV.fetch('DATADOG_TRACE_AGENT_HOSTNAME', 'datadog')
 }
 
 if Rails.env.production? && Horizon.config[:basic_auth_pass].blank?

--- a/config/initializers/dogstatsd.rb
+++ b/config/initializers/dogstatsd.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Horizon
+  def self.dogstatsd
+    @dogstatsd ||= Datadog::Statsd.new(
+      Horizon.config[:datadog_trace_agent_hostname],
+      8125,
+      tags: ["service:#{Horizon.config[:datadog_service_name]}"]
+    )
+  end
+end


### PR DESCRIPTION
This PR adds DogStatsD (via Datadog's [ruby gem](https://github.com/DataDog/dogstatsd-ruby)) to `horizon`, which will allow us to send custom metrics to our Datadog instance. This should be generally useful, but it is being added now to[ support better monitor and tracking of our system runtimes versions](https://artsyproduct.atlassian.net/browse/PLATFORM-5073). 

There will be a follow-up PR to instrument implement runtime version monitoring, but I wanted to keep the PRs focused and separate. 


