### PR TITLE
chore: use docker buildkit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
     executor: hokusai/deploy
     steps:
       - hokusai/setup-docker
-      - run: hokusai registry pull --tag "$CIRCLE_SHA1"
+      - run: hokusai registry pull --tag "$CIRCLE_SHA1"-builder
       - hokusai/run-tests:
           flags: --no-build
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,13 +42,13 @@ workflows:
           project_id: 38
 
       - artsy-remote-docker/buildkit-build:
-            <<: *not_staging_or_release
-            context: hokusai
-            executor: hokusai/beta
-            name: builder-image-build
-            pre-steps:
-              - run:
-                  command: echo 'export BUILD_TARGET="builder";' >> $BASH_ENV
+          <<: *not_staging_or_release
+          context: hokusai
+          executor: hokusai/beta
+          name: builder-image-build
+          pre-steps:
+            - run:
+                command: echo 'export BUILD_TARGET="builder";' >> $BASH_ENV
 
       - artsy-remote-docker/buildkit-push:
           <<: *not_staging_or_release
@@ -68,12 +68,12 @@ workflows:
             - build
 
       - artsy-remote-docker/buildkit-build:
-        <<: *only_main
-        context: hokusai
-        executor: hokusai/beta
-        name: production-image-build
-        requires:
-          - builder-image-build
+          <<: *only_main
+          context: hokusai
+          executor: hokusai/beta
+          name: production-image-build
+          requires:
+            - builder-image-build
 
       - artsy-remote-docker/buildkit-push:
           <<: *only_main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,25 +41,25 @@ workflows:
           context: horizon
           project_id: 38
 
-     - artsy-remote-docker/buildkit-build:
-          <<: *not_staging_or_release
-          context: hokusai
-          executor: hokusai/beta
-          name: builder-image-build
-          pre-steps:
-            - run:
-                command: echo 'export BUILD_TARGET="builder";' >> $BASH_ENV
+      - artsy-remote-docker/buildkit-build:
+            <<: *not_staging_or_release
+            context: hokusai
+            executor: hokusai/beta
+            name: builder-image-build
+            pre-steps:
+              - run:
+                  command: echo 'export BUILD_TARGET="builder";' >> $BASH_ENV
 
-      - artsy-remote-docker/buildkit-push:
-          <<: *not_staging_or_release
-          context: hokusai
-          executor: hokusai/beta
-          name: builder-image-push
-          requires:
-            - builder-image-build
-          pre-steps:
-            - run:
-                command: echo 'export BUILD_TARGET="builder";' >> $BASH_ENV
+        - artsy-remote-docker/buildkit-push:
+            <<: *not_staging_or_release
+            context: hokusai
+            executor: hokusai/beta
+            name: builder-image-push
+            requires:
+              - builder-image-build
+            pre-steps:
+              - run:
+                  command: echo 'export BUILD_TARGET="builder";' >> $BASH_ENV
 
       - test:
           <<: *not_staging_or_release
@@ -67,13 +67,13 @@ workflows:
           requires:
             - build
 
-       - artsy-remote-docker/buildkit-build:
-          <<: *only_main
-          context: hokusai
-          executor: hokusai/beta
-          name: production-image-build
-          requires:
-            - builder-image-build
+      - artsy-remote-docker/buildkit-build:
+        <<: *only_main
+        context: hokusai
+        executor: hokusai/beta
+        name: production-image-build
+        requires:
+          - builder-image-build
 
       - artsy-remote-docker/buildkit-push:
           <<: *only_main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,16 +50,16 @@ workflows:
               - run:
                   command: echo 'export BUILD_TARGET="builder";' >> $BASH_ENV
 
-        - artsy-remote-docker/buildkit-push:
-            <<: *not_staging_or_release
-            context: hokusai
-            executor: hokusai/beta
-            name: builder-image-push
-            requires:
-              - builder-image-build
-            pre-steps:
-              - run:
-                  command: echo 'export BUILD_TARGET="builder";' >> $BASH_ENV
+      - artsy-remote-docker/buildkit-push:
+          <<: *not_staging_or_release
+          context: hokusai
+          executor: hokusai/beta
+          name: builder-image-push
+          requires:
+            - builder-image-build
+          pre-steps:
+            - run:
+                command: echo 'export BUILD_TARGET="builder";' >> $BASH_ENV
 
       - test:
           <<: *not_staging_or_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ workflows:
       - artsy-remote-docker/buildkit-build:
           <<: *not_staging_or_release
           context: hokusai
-          executor: hokusai/beta
+          executor: hokusai/deploy
           name: builder-image-build
           pre-steps:
             - run:
@@ -53,7 +53,7 @@ workflows:
       - artsy-remote-docker/buildkit-push:
           <<: *not_staging_or_release
           context: hokusai
-          executor: hokusai/beta
+          executor: hokusai/deploy
           name: builder-image-push
           requires:
             - builder-image-build
@@ -70,7 +70,7 @@ workflows:
       - artsy-remote-docker/buildkit-build:
           <<: *only_main
           context: hokusai
-          executor: hokusai/beta
+          executor: hokusai/deploy
           name: production-image-build
           requires:
             - builder-image-build
@@ -78,7 +78,7 @@ workflows:
       - artsy-remote-docker/buildkit-push:
           <<: *only_main
           context: hokusai
-          executor: hokusai/beta
+          executor: hokusai/deploy
           name: production-image-push
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ workflows:
           <<: *only_main
           project-name: horizon
           requires:
-            - push-staging-image
+            - production-image-push
 
       - hokusai/deploy-production:
           <<: *only_release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ workflows:
           <<: *not_staging_or_release
           context: hokusai
           requires:
-            - build
+            - builder-image-push
 
       - artsy-remote-docker/buildkit-build:
           <<: *only_main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ orbs:
 
 jobs:
   test:
+    executor: hokusai/deploy
     steps:
       - hokusai/setup-docker
       - run: hokusai registry pull --tag "$CIRCLE_SHA1"-builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,13 +41,25 @@ workflows:
           context: horizon
           project_id: 38
 
-      - artsy-remote-docker/build:
+     - artsy-remote-docker/buildkit-build:
           <<: *not_staging_or_release
           context: hokusai
-          name: build
+          executor: hokusai/beta
+          name: builder-image-build
           pre-steps:
             - run:
-                command: echo 'export BUILD_TARGET="builder"' >> $BASH_ENV
+                command: echo 'export BUILD_TARGET="builder";' >> $BASH_ENV
+
+      - artsy-remote-docker/buildkit-push:
+          <<: *not_staging_or_release
+          context: hokusai
+          executor: hokusai/beta
+          name: builder-image-push
+          requires:
+            - builder-image-build
+          pre-steps:
+            - run:
+                command: echo 'export BUILD_TARGET="builder";' >> $BASH_ENV
 
       - test:
           <<: *not_staging_or_release
@@ -55,15 +67,22 @@ workflows:
           requires:
             - build
 
-      - artsy-remote-docker/build:
+       - artsy-remote-docker/buildkit-build:
           <<: *only_main
           context: hokusai
-          name: push-staging-image
+          executor: hokusai/beta
+          name: production-image-build
+          requires:
+            - builder-image-build
+
+      - artsy-remote-docker/buildkit-push:
+          <<: *only_main
+          context: hokusai
+          executor: hokusai/beta
+          name: production-image-push
           requires:
             - test
-          pre-steps:
-            - run:
-                command: echo 'export BUILD_TARGET="production"' >> $BASH_ENV
+            - production-image-build
 
       - hokusai/deploy-staging:
           <<: *only_main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,6 @@ orbs:
 
 jobs:
   test:
-    executor: hokusai/deploy
     steps:
       - hokusai/setup-docker
       - run: hokusai registry pull --tag "$CIRCLE_SHA1"-builder
@@ -44,7 +43,6 @@ workflows:
       - artsy-remote-docker/buildkit-build:
           <<: *not_staging_or_release
           context: hokusai
-          executor: hokusai/deploy
           name: builder-image-build
           pre-steps:
             - run:
@@ -53,7 +51,6 @@ workflows:
       - artsy-remote-docker/buildkit-push:
           <<: *not_staging_or_release
           context: hokusai
-          executor: hokusai/deploy
           name: builder-image-push
           requires:
             - builder-image-build
@@ -70,7 +67,6 @@ workflows:
       - artsy-remote-docker/buildkit-build:
           <<: *only_main
           context: hokusai
-          executor: hokusai/deploy
           name: production-image-build
           requires:
             - builder-image-build
@@ -78,7 +74,6 @@ workflows:
       - artsy-remote-docker/buildkit-push:
           <<: *only_main
           context: hokusai
-          executor: hokusai/deploy
           name: production-image-push
           requires:
             - test


### PR DESCRIPTION
This PR updated the `.circleci/config.yml` file to use docker buildkit. For more context and motivation please see the Slack [thread](https://artsy.slack.com/archives/CA8SANW3W/p1687874328399399). 

### Motivation
While merging an unrelated PR, we ran into an issue where the production image of our multi-stage build was not being pushed to our registry, due to having the same git SHA, which we use as the image tag. 

### Solution
By utilizing our existing [artsy-remote-docker/buildkit-*](https://github.com/artsy/orbs/blob/7c26a69a6b560d6acb4b31fb267244d89ea42d6a/src/remote-docker/remote-docker.yml#L256) steps, we're able to leverage docker's [buildkit](https://docs.docker.com/build/buildkit/), as well as benefit from the auto appending of the stage to the image tag. For example:
```
horizon:main: hokusai registry images
Image Pushed At           | Image Tags
----------------------------------------------------------
2023-06-27 12:03:50-04:00 | d98685f91ae9bf3886791e3c3b5020920c55a77c-builder
2023-06-27 08:23:55-04:00 | b615a89d8f25b7c594ae9a6f7935484187ae1576
2023-06-27 08:23:47-04:00 | 1601aae393f07ab514bbf2cc99e77965dc4f69e2
2023-06-27 08:23:42-04:00 | c57874f4e8d697e46ffd2867c5ec9c40b8daa6ff
2023-06-26 15:59:15-04:00 | 5d05480a01f4311c72647c5326ef0b15b19d8d21, 400cd47b2779dbe9b9fcc68dcbf865abbb5872b4
```