### PR TITLE
feat: send runtime version status to datadog

### DIFF
--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -56,19 +56,9 @@ class ProjectDataService
 
   def update_dependency(name, version)
     dependency = @project.dependencies.find_or_initialize_by(name: name)
-
     dependency.update(version: version)
 
-    Horizon.dogstatsd.gauge(
-      'runtime.version_status', # Metric name
-      dependency.update_required? ? -1 : 1, # The value associated with the metric. -1 = out of date, 1 = up to date
-      tags: [
-        "runtime:#{name}",
-        "project:#{@project.name}",
-        "criticality:#{@project.criticality}",
-        "team:#{@project.tags&.join(':')}"
-      ]
-    )
+    report_runtime_version_status(dependency)
 
     dependency
   end
@@ -120,5 +110,18 @@ class ProjectDataService
     file&.to_h
   rescue Octokit::NotFound
     # file not found - don't fail if ruby project doesn't have node etc
+  end
+
+  def report_runtime_version_status(dependency)
+    Horizon.dogstatsd.gauge(
+      'runtime.version_status', # Metric name
+      dependency.update_required? ? -1 : 1, # The value associated with the metric. -1 = out of date, 1 = up to date
+      tags: [
+        "runtime:#{dependency.name}",
+        "project:#{@project.name}",
+        "criticality:#{@project.criticality}",
+        "team:#{@project.tags&.join(':')}"
+      ]
+    )
   end
 end

--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -120,7 +120,7 @@ class ProjectDataService
         "runtime:#{dependency.name}",
         "project:#{@project.name}",
         "criticality:#{@project.criticality}",
-        "team:#{@project.tags&.join(':')}"
+        "team:#{@project.tags&.none? ? 'none' : @project.tags.join(':')}"
       ]
     )
   end

--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -60,9 +60,10 @@ class ProjectDataService
     dependency.update(version: version)
 
     Horizon.dogstatsd.gauge(
-      "runtime.#{name}.version_status", # Metric name
+      'runtime.version_status', # Metric name
       dependency.update_required? ? -1 : 1, # The value associated with the metric. -1 = out of date, 1 = up to date
       tags: [
+        "runtime:#{name}",
         "project:#{@project.name}",
         "criticality:#{@project.criticality}",
         "team:#{@project.tags&.join(':')}"

--- a/spec/services/project_data_service_spec.rb
+++ b/spec/services/project_data_service_spec.rb
@@ -101,9 +101,9 @@ RSpec.describe ProjectDataService, type: :service do
       expect(project.dependencies.last.name).to eq('node')
       expect(project.dependencies.last.version).to eq('12')
       expect(Horizon.dogstatsd).to have_received(:gauge)
-        .with('runtime.ruby.version_status', -1, tags: ['project:candela', 'criticality:1', 'team:engineering']).once
+        .with('runtime.version_status', -1, tags: ['project:candela', 'criticality:1', 'team:engineering']).once
       expect(Horizon.dogstatsd).to have_received(:gauge)
-        .with('runtime.node.version_status', 1, tags: ['project:candela', 'criticality:1', 'team:engineering']).once
+        .with('runtime.version_status', 1, tags: ['project:candela', 'criticality:1', 'team:engineering']).once
     end
   end
 

--- a/spec/services/project_data_service_spec.rb
+++ b/spec/services/project_data_service_spec.rb
@@ -101,9 +101,9 @@ RSpec.describe ProjectDataService, type: :service do
       expect(project.dependencies.last.name).to eq('node')
       expect(project.dependencies.last.version).to eq('12')
       expect(Horizon.dogstatsd).to have_received(:gauge)
-        .with('runtime.version_status', -1, tags: ['project:candela', 'criticality:1', 'team:engineering']).once
+        .with('runtime.version_status', -1, tags: ['runtime:ruby', 'project:candela', 'criticality:1', 'team:engineering']).once
       expect(Horizon.dogstatsd).to have_received(:gauge)
-        .with('runtime.version_status', 1, tags: ['project:candela', 'criticality:1', 'team:engineering']).once
+        .with('runtime.version_status', 1, tags: ['runtime:node', 'project:candela', 'criticality:1', 'team:engineering']).once
     end
   end
 

--- a/spec/services/project_data_service_spec.rb
+++ b/spec/services/project_data_service_spec.rb
@@ -100,10 +100,26 @@ RSpec.describe ProjectDataService, type: :service do
       expect(project.dependencies.first.version).to eq('2.5.7')
       expect(project.dependencies.last.name).to eq('node')
       expect(project.dependencies.last.version).to eq('12')
-      expect(Horizon.dogstatsd).to have_received(:gauge)
-        .with('runtime.version_status', -1, tags: ['runtime:ruby', 'project:candela', 'criticality:1', 'team:engineering']).once
-      expect(Horizon.dogstatsd).to have_received(:gauge)
-        .with('runtime.version_status', 1, tags: ['runtime:node', 'project:candela', 'criticality:1', 'team:engineering']).once
+      expect(Horizon.dogstatsd).to have_received(:gauge).with(
+        'runtime.version_status',
+        -1,
+        tags: [
+          'runtime:ruby',
+          'project:candela',
+          'criticality:1',
+          'team:engineering'
+        ]
+      ).once
+      expect(Horizon.dogstatsd).to have_received(:gauge).with(
+        'runtime.version_status',
+        1,
+        tags: [
+          'runtime:node',
+          'project:candela',
+          'criticality:1',
+          'team:engineering'
+        ]
+      ).once
     end
   end
 

--- a/spec/services/project_data_service_spec.rb
+++ b/spec/services/project_data_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProjectDataService, type: :service do
   let(:org) { Organization.create! name: 'artsy' }
   let(:profile) { org.profiles.create!(basic_password: 'foo') }
   let(:project) do
-    org.projects.create!(name: 'candela').tap do |p|
+    org.projects.create!(name: 'candela', criticality: 1, tags: []).tap do |p|
       p.stages.create!(name: 'main', profile: profile)
       p.stages.create!(name: 'production', profile: profile)
     end
@@ -93,11 +93,17 @@ RSpec.describe ProjectDataService, type: :service do
 
   describe 'update_dependencies' do
     it 'calls update_dependency with ruby and node' do
+      allow(Horizon.dogstatsd).to receive(:gauge)
       ProjectDataService.new(project).update_dependencies
+
       expect(project.dependencies.first.name).to eq('ruby')
       expect(project.dependencies.first.version).to eq('2.5.7')
       expect(project.dependencies.last.name).to eq('node')
       expect(project.dependencies.last.version).to eq('12')
+      expect(Horizon.dogstatsd).to have_received(:gauge)
+        .with('runtime.ruby.version_status', -1, tags: ['project:candela', 'criticality:1', 'team:engineering']).once
+      expect(Horizon.dogstatsd).to have_received(:gauge)
+        .with('runtime.node.version_status', 1, tags: ['project:candela', 'criticality:1', 'team:engineering']).once
     end
   end
 

--- a/spec/services/project_data_service_spec.rb
+++ b/spec/services/project_data_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ProjectDataService, type: :service do
   let(:org) { Organization.create! name: 'artsy' }
   let(:profile) { org.profiles.create!(basic_password: 'foo') }
   let(:project) do
-    org.projects.create!(name: 'candela', criticality: 1, tags: []).tap do |p|
+    org.projects.create!(name: 'candela', criticality: 1, tags: ['engineering']).tap do |p|
       p.stages.create!(name: 'main', profile: profile)
       p.stages.create!(name: 'production', profile: profile)
     end


### PR DESCRIPTION
### Problem 
<!-- the original problem or rationale -->
We don't currently have a way of effectively informing team members when their project's runtime dependencies are out of date. While `horizon` does have a UI to display which projects need runtime updates, engineers do not seem to be [using it](https://artsy.slack.com/archives/C02BC3HEJ/p1687284843609379). 

### Solution
<!-- the solution eventually agreed upon -->
Since we are already updating project runtime status in `horizon`, we can also send this information to `datadog`, which will allow us to build dashboards, monitors, and trigger alerts. 

[PLATFORM-5073]


[PLATFORM-5073]: https://artsyproduct.atlassian.net/browse/PLATFORM-5073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ