### PR TITLE
feature: send dependency version to datadog

### DIFF
--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -113,15 +113,23 @@ class ProjectDataService
   end
 
   def report_runtime_version_status(dependency)
+    tags = [
+      "runtime:#{dependency.name}",
+      "project:#{@project.name}",
+      "criticality:#{@project.criticality}",
+      "tags:#{@project.tags&.none? ? 'none' : @project.tags.join(':')}"
+    ]
+
     Horizon.dogstatsd.gauge(
       'runtime.version_status', # Metric name
       dependency.update_required? ? -1 : 1, # The value associated with the metric. -1 = out of date, 1 = up to date
-      tags: [
-        "runtime:#{dependency.name}",
-        "project:#{@project.name}",
-        "criticality:#{@project.criticality}",
-        "team:#{@project.tags&.none? ? 'none' : @project.tags.join(':')}"
-      ]
+      tags: tags
+    )
+
+    Horizon.dogstatsd.gauge(
+      'runtime.version', # Metric name
+      dependency.version, # The value associated with the metric. -1 = out of date, 1 = up to date
+      tags: tags
     )
   end
 end

--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -58,7 +58,7 @@ class ProjectDataService
     dependency = @project.dependencies.find_or_initialize_by(name: name)
     dependency.update(version: version)
 
-    report_runtime_version_status(dependency)
+    report_runtime_version(dependency)
 
     dependency
   end
@@ -112,7 +112,7 @@ class ProjectDataService
     # file not found - don't fail if ruby project doesn't have node etc
   end
 
-  def report_runtime_version_status(dependency)
+  def report_runtime_version(dependency)
     tags = [
       "runtime:#{dependency.name}",
       "project:#{@project.name}",

--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -128,7 +128,7 @@ class ProjectDataService
 
     Horizon.dogstatsd.gauge(
       'runtime.version', # Metric name
-      dependency.version, # The value associated with the metric. -1 = out of date, 1 = up to date
+      dependency.version,
       tags: tags
     )
   end

--- a/spec/services/project_data_service_spec.rb
+++ b/spec/services/project_data_service_spec.rb
@@ -92,33 +92,41 @@ RSpec.describe ProjectDataService, type: :service do
   end
 
   describe 'update_dependencies' do
-    it 'calls update_dependency with ruby and node' do
+    before do
       allow(Horizon.dogstatsd).to receive(:gauge)
       ProjectDataService.new(project).update_dependencies
+    end
 
+    it 'calls update_dependency with ruby and node' do
       expect(project.dependencies.first.name).to eq('ruby')
       expect(project.dependencies.first.version).to eq('2.5.7')
       expect(project.dependencies.last.name).to eq('node')
       expect(project.dependencies.last.version).to eq('12')
+    end
+
+    it 'sends metrics with the correct payloads' do
+      node_tags = ['runtime:node', 'project:candela', 'criticality:1', 'tags:engineering']
+      ruby_tags = ['runtime:ruby', 'project:candela', 'criticality:1', 'tags:engineering']
+
       expect(Horizon.dogstatsd).to have_received(:gauge).with(
         'runtime.version_status',
         -1,
-        tags: [
-          'runtime:ruby',
-          'project:candela',
-          'criticality:1',
-          'team:engineering'
-        ]
+        tags: ruby_tags
       ).once
       expect(Horizon.dogstatsd).to have_received(:gauge).with(
         'runtime.version_status',
         1,
-        tags: [
-          'runtime:node',
-          'project:candela',
-          'criticality:1',
-          'team:engineering'
-        ]
+        tags: node_tags
+      ).once
+      expect(Horizon.dogstatsd).to have_received(:gauge).with(
+        'runtime.version',
+        '12',
+        tags: node_tags
+      ).once
+      expect(Horizon.dogstatsd).to have_received(:gauge).with(
+        'runtime.version',
+        '2.5.7',
+        tags: ruby_tags
       ).once
     end
   end


### PR DESCRIPTION
This PR is a follow up to #581 and makes the following changes:

- Adds another metric, `runtime.version`, which sends the current dependency version so this can be displayed in the dashboard. 
- Updates the `team` tag to be `tag`, which will provide greater flexibility to label and slice data. ([see comment on previous PR](https://github.com/artsy/horizon/pull/581#discussion_r1246666463))