### PR TITLE
refactor: send runtime version as tag to datadog

### DIFF
--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -113,23 +113,16 @@ class ProjectDataService
   end
 
   def report_runtime_version(dependency)
-    tags = [
-      "runtime:#{dependency.name}",
-      "project:#{@project.name}",
-      "criticality:#{@project.criticality}",
-      "tags:#{@project.tags&.none? ? 'none' : @project.tags.join(':')}"
-    ]
-
     Horizon.dogstatsd.gauge(
       'runtime.version_status', # Metric name
       dependency.update_required? ? -1 : 1, # The value associated with the metric. -1 = out of date, 1 = up to date
-      tags: tags
-    )
-
-    Horizon.dogstatsd.gauge(
-      'runtime.version', # Metric name
-      dependency.version,
-      tags: tags
+      tags: [
+        "runtime:#{dependency.name}",
+        "runtime_version:#{dependency.version}",
+        "project:#{@project.name}",
+        "criticality:#{@project.criticality}",
+        "tags:#{@project.tags&.none? ? 'none' : @project.tags.join(':')}"
+      ]
     )
   end
 end

--- a/spec/services/project_data_service_spec.rb
+++ b/spec/services/project_data_service_spec.rb
@@ -105,8 +105,8 @@ RSpec.describe ProjectDataService, type: :service do
     end
 
     it 'sends metrics with the correct payloads' do
-      node_tags = ['runtime:node', 'project:candela', 'criticality:1', 'tags:engineering']
-      ruby_tags = ['runtime:ruby', 'project:candela', 'criticality:1', 'tags:engineering']
+      node_tags = ['runtime:node', 'runtime_version:12', 'project:candela', 'criticality:1', 'tags:engineering']
+      ruby_tags = ['runtime:ruby', 'runtime_version:2.5.7', 'project:candela', 'criticality:1', 'tags:engineering']
 
       expect(Horizon.dogstatsd).to have_received(:gauge).with(
         'runtime.version_status',
@@ -117,16 +117,6 @@ RSpec.describe ProjectDataService, type: :service do
         'runtime.version_status',
         1,
         tags: node_tags
-      ).once
-      expect(Horizon.dogstatsd).to have_received(:gauge).with(
-        'runtime.version',
-        '12',
-        tags: node_tags
-      ).once
-      expect(Horizon.dogstatsd).to have_received(:gauge).with(
-        'runtime.version',
-        '2.5.7',
-        tags: ruby_tags
       ).once
     end
   end


### PR DESCRIPTION
This PR refactors the approach set out in #582 to send the `runtime_version` as a datadog `tag` instead of its own metric. 

### Problem
Datadog expects a float or integer as a value. However, for the `Dependency` model's `version` field we store valid semver values as strings. So we could be sending `18.15`, `3.0.2`, `>= 18`, for example. Of these, only the first (`18.15`), would be valid and a usable datadog metric value. 

### Solution
If we send it as a tag, we can send any string value and filter it and display it in the dashboard. This prevents us from having to introduce a lot of code to normalize version values. 

### Considerations
Since we have a large range of values that can be passed in as the `tags` we have to monitor the [cost associated with the custom metric](https://docs.datadoghq.com/account_management/billing/custom_metrics/?tab=countrate), to make sure we don't see uncontrolled exponential growth. While this isn't expected since the tage values should remain fairly constant, we will keep an eye on the cost for a few weeks. 