### PR TITLE
refactor: normalize runtime version

### DIFF
--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -118,7 +118,7 @@ class ProjectDataService
       dependency.update_required? ? -1 : 1, # The value associated with the metric. -1 = out of date, 1 = up to date
       tags: [
         "runtime:#{dependency.name}",
-        "runtime_version:#{dependency.version}",
+        "runtime_version:#{dependency.version == 'unknown version' ? 'none' : dependency.version.delete('^0-9.')}",
         "project:#{@project.name}",
         "criticality:#{@project.criticality}",
         "tags:#{@project.tags&.none? ? 'none' : @project.tags.join(':')}"


### PR DESCRIPTION
### Problem 
<!-- the original problem or rationale -->
It appears that tags can't include certain symbols. As the SemVer range symbols `=<>` are being stripped in `datadog` and displayed as `_` in the UI. So: 

<img width="204" alt="Screenshot 2023-06-30 at 3 17 44 PM" src="https://github.com/artsy/horizon/assets/38149304/bc7d3e87-9be7-4500-8d3b-4e3f84bc5501">

### Solution
<!-- the solution eventually agreed upon -->
This PR builds on #583 and normalized the string values by removing everything but the `.` and numbers that are sent as the `runtime_version` tag. 

### Considerations
<!-- any alternatives considered, and any to-dos, considerations for the future, or fall-out for other developers -->

Because we accept semver ranges, the actual version could differ from the specific version listed. For example, if the accepted `node` version is `>=18.15.0` (defined in the `package.json` as the `engine`, but we are actually using `18.20.0` in the image, there could be a slight mismatch between the version shown in `datadog` and what is being used. An alternative approach would be to check the `dockerfile` to get authoritative single version. I am opting not to do this, as I don't think the value is there to refactor existing `horizon` code at this point. I think this gets us reasonably close and an accurate enough heuristic.

[PLATFORM-5073]

[PLATFORM-5073]: https://artsyproduct.atlassian.net/browse/PLATFORM-5073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ