### PR TITLE
fix: check for nil tag values instead of none

### DIFF
--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -121,7 +121,7 @@ class ProjectDataService
         "runtime_version:#{dependency.version == 'unknown version' ? 'none' : dependency.version.delete('^0-9.')}",
         "project:#{@project.name}",
         "criticality:#{@project.criticality}",
-        "tags:#{@project.tags&.blank? ? 'none' : @project.tags.join(':')}"
+        "tags:#{@project.tags.blank? ? 'none' : @project.tags.join(':')}"
       ]
     )
   end

--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -121,7 +121,7 @@ class ProjectDataService
         "runtime_version:#{dependency.version == 'unknown version' ? 'none' : dependency.version.delete('^0-9.')}",
         "project:#{@project.name}",
         "criticality:#{@project.criticality}",
-        "tags:#{@project.tags&.none? ? 'none' : @project.tags.join(':')}"
+        "tags:#{@project.tags&.nil? ? 'none' : @project.tags.join(':')}"
       ]
     )
   end

--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -121,7 +121,7 @@ class ProjectDataService
         "runtime_version:#{dependency.version == 'unknown version' ? 'none' : dependency.version.delete('^0-9.')}",
         "project:#{@project.name}",
         "criticality:#{@project.criticality}",
-        "tags:#{@project.tags&.nil? ? 'none' : @project.tags.join(':')}"
+        "tags:#{@project.tags&.blank? ? 'none' : @project.tags.join(':')}"
       ]
     )
   end


### PR DESCRIPTION
### Problem 
The default value for a `Project`'s `tags` field is `nil`, not an empty `array` as I had mistakenly written this for. As a result, the first run of this failed once it his a project with a `tag` value of `nil`. 

```
To use retry middleware with Faraday v2.0+, install `faraday-retry` gem
rake aborted!
NoMethodError: undefined method `join' for nil:NilClass
/app/app/services/project_data_service.rb:124:in `report_runtime_version'
/app/app/services/project_data_service.rb:61:in `update_dependency'
/app/app/services/project_data_service.rb:54:in `update_dependencies'
/app/app/services/project_data_service.rb:20:in `update_computed_properties'
/app/app/services/project_data_service.rb:15:in `block in refresh_data_for_org'
/usr/local/bundle/ruby/3.0.0/gems/activerecord-6.1.6.1/lib/active_record/relation/delegation.rb:88:in `each'
/usr/local/bundle/ruby/3.0.0/gems/activerecord-6.1.6.1/lib/active_record/relation/delegation.rb:88:in `each'
/app/app/services/project_data_service.rb:14:in `refresh_data_for_org'
/app/Rakefile:17:in `block (3 levels) in <top (required)>'
/usr/local/bundle/ruby/3.0.0/gems/activerecord-6.1.6.1/lib/active_record/relation/delegation.rb:88:in `each'
/usr/local/bundle/ruby/3.0.0/gems/activerecord-6.1.6.1/lib/active_record/relation/delegation.rb:88:in `each'
/app/Rakefile:16:in `block (2 levels) in <top (required)>'
/usr/local/bundle/ruby/3.0.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/usr/local/bundle/bin/bundle:23:in `load'
/usr/local/bundle/bin/bundle:23:in `<main>'
Tasks: TOP => cron:refresh_components
(See full trace by running task with --trace)
```

### Solution
This PR updates the `datadog` call to check for `nil` values instead. 