### PR TITLE
chore: Bump rails defaults to 6.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ Bundler.require(*Rails.groups)
 module Horizon
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 6.0
+    config.load_defaults 6.1
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
chore: Bump rails defaults to 6.1 so that the application can truly run in Rails 6.1!