### PR TITLE
chore: Set exact Rails version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,11 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.0.2"
 
+gem "rails", "6.1.7.9"
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "coffee-rails"
 gem "dogstatsd-ruby", require: "datadog/statsd" # send metrics to datadog agent
-gem "rails", "~> 6.1.7.7"
 # Use postgresql as the database for Active Record
 gem "pg"
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,7 +373,7 @@ DEPENDENCIES
   octokit (~> 4.0)
   pg
   puma (~> 5.6)
-  rails (~> 6.1.7.7)
+  rails (= 6.1.7.9)
   redis
   releasecop (>= 0.0.15)
   rspec-rails


### PR DESCRIPTION
This PR does two very nit-picky things:

* pulls out the rails gem into it's own section towards the top
* sets the exact Rails version

Mostly this is to keep things more consistent in our Rails apps but it also makes the `artsy_ruby_doctor` project work correctly.

/cc @artsy/amber-devs