### PR TITLE
feat: make deploy blocks' explanations and ages more easily accessible

### DIFF
--- a/app/javascript/apps/Project/index.tsx
+++ b/app/javascript/apps/Project/index.tsx
@@ -113,7 +113,7 @@ export const ProjectShow: React.FC<ProjectShowProps> = ({ project, tags }) => {
                     color="white100"
                     underlineBehavior="none"
                   >
-                    <Flex>
+                    <Flex title={`${block.description} (${block.created_at})`}>
                       {/** @ts-ignore */}
                       <LockIcon fill="white100" mr={0.5} />
                       Blocked

--- a/app/javascript/components/Project/ProjectSummary.tsx
+++ b/app/javascript/components/Project/ProjectSummary.tsx
@@ -28,7 +28,11 @@ export const ProjectSummary: React.FC<Project> = ({
     >
       <Link href={projectPath(id)} underlineBehavior="none">
         {block && (
-          <Box position="absolute" right={3}>
+          <Box
+            position="absolute"
+            right={3}
+            title={`${block.description} (${block.created_at})`}
+          >
             <Button variant="primaryBlack" size="small">
               Blocked
             </Button>

--- a/app/javascript/components/Projects/ProjectsList.tsx
+++ b/app/javascript/components/Projects/ProjectsList.tsx
@@ -118,7 +118,11 @@ export const ProjectsListRow: React.FC<{ project: Project }> = ({
             </Sans>
 
             {block && (
-              <Button size="small" ml={1}>
+              <Button
+                size="small"
+                ml={1}
+                title={`${block.description} (${block.created_at})`}
+              >
                 Blocked
               </Button>
             )}


### PR DESCRIPTION
This brings deploy blocks' explanations and ages into hover-style tool-tips on the "blocked" element in grid and list views.

Inspired https://github.com/artsy/horizon/pull/677.