### PR TITLE
chore: update pr description

### DIFF
--- a/app/services/deploy_service.rb
+++ b/app/services/deploy_service.rb
@@ -61,7 +61,7 @@ class DeployService
       deploy_strategy.arguments["base"],
       deploy_strategy.arguments["head"],
       "Deploy",
-      "This is an automatically generated release PR!\n\nHumans: remember to _merge_ (not squash or rebase) this PR."
+      "This is an automatically generated release PR!"
     )
   end
 


### PR DESCRIPTION
Since we can globally enable automatic PR merging, we can remove this text.