### PR TITLE
chore: dont process orbs if circle_config is nil

### DIFF
--- a/app/services/project_data_service.rb
+++ b/app/services/project_data_service.rb
@@ -43,6 +43,7 @@ class ProjectDataService
 
   def orbs
     orbs = []
+    return orbs unless @circle_config
     @circle_config.include?("artsy/auto@") && orbs.push("auto")
     @circle_config.include?("artsy/hokusai@") && orbs.push("hokusai")
     @circle_config.include?("artsy/release@") && orbs.push("release")

--- a/spec/services/project_data_service_spec.rb
+++ b/spec/services/project_data_service_spec.rb
@@ -183,5 +183,14 @@ RSpec.describe ProjectDataService, type: :service do
       orbs = ProjectDataService.new(project).orbs
       expect(orbs).to eq(%w[hokusai release yarn])
     end
+
+    it "returns an empty array if ci config is nil" do
+      allow_any_instance_of(Octokit::Client).to receive(:contents)
+        .with(project.github_repo.to_s, path: ".circleci/config.yml")
+        .and_return(nil)
+
+      orbs = ProjectDataService.new(project).orbs
+      expect(orbs).to eq([])
+    end
   end
 end


### PR DESCRIPTION
Solves https://artsyproduct.atlassian.net/browse/PHIRE-1681
Related [slack thread](https://artsy.slack.com/archives/CA8SANW3W/p1743411026076479)

Make processing more resilient when circleci config is missing (if new project is added).