### PR TITLE
Migrate from asdf to mise in setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -8,11 +8,11 @@ brew bundle --file=- <<EOF
 brew 'postgresql@14', restart_service: true
 EOF
 
-if command -v asdf >/dev/null; then
-  echo "Installing language dependencies with asdf"
-  asdf install
+if command -v mise >/dev/null; then
+  echo "Installing language dependencies with mise"
+  mise install
 else
-  echo "Skipping language dependencies installation (asdf not found)"
+  echo "Skipping language dependencies installation (mise not found)"
 fi
 
 echo "install the bundler version locked in Gemfile.lock, if any..."


### PR DESCRIPTION
## Summary

This PR migrates the repository setup script from asdf to mise:
- Updates `bin/setup` to check for `mise` instead of `asdf`
- Changes `asdf install` command to `mise install`
- Updates messaging to reference mise
- Keeps `.tool-versions` files unchanged (they're compatible with mise)

## Related

- RFC: https://github.com/artsy/README/issues/550

🤖 Generated with [Claude Code](https://claude.ai/code)