### PR TITLE
feat: production to use HPAv2

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -127,7 +127,7 @@ spec:
       - name: secrets
         emptyDir: {}
 ---
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: horizon-web
@@ -139,7 +139,13 @@ spec:
     name: horizon-web
   minReplicas: 2
   maxReplicas: 3
-  targetCPUUtilizationPercentage: 70
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
HPAv2 is at GA status as of Kubernetes v1.23 which is our current version. v2 adds the ability to scale by memory, by custom metrics, and by combination of metrics. Let us switch to v2.

Jira: PHIRE-3107