### PR TITLE
chore: impose 10d cooldown period before dependency updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ USER deploy
 # TODO: look into buildkit to prevent re-installing node modules after changing gems
 COPY --chown=deploy:deploy Gemfile Gemfile.lock ./
 # RUN bundle install -j4 --path /usr/local/bundle-prod --without development test && \
-RUN bundle install -j4 --path /usr/local/bundle
+RUN bundle config set --global path /usr/local/bundle && \
+    bundle install -j4
 # bundle clean
 
 # Set up packages, empty cache to save space

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source "https://rubygems.org", cooldown: 10
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,7 +394,7 @@ DEPENDENCIES
   webpacker (~> 5.4)
 
 RUBY VERSION
-   ruby 3.3.0p0
+  ruby 3.3.0p0
 
 BUNDLED WITH
-   2.4.5
+  4.0.17


### PR DESCRIPTION
Mirrors [artsy/gravity#20262](https://github.com/artsy/gravity/pull/20262) — upgrades `bundler` for the ability to specify a `cooldown` argument, delaying dependency updates until they've had 10 days to be vetted elsewhere. This mitigates supply-chain risk from a compromised gem release being auto-picked-up before the community notices.

Requires Bundler >= 4.0.13 for the `cooldown` source option; this repo was still on the 2.x line, so this bumps bundler across a major version (2.4.5 → 4.0.17).

Assisted by Claude Code Sonnet 5