### PR TITLE
fix: use --local scope for bundle path config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ USER deploy
 # TODO: look into buildkit to prevent re-installing node modules after changing gems
 COPY --chown=deploy:deploy Gemfile Gemfile.lock ./
 # RUN bundle install -j4 --path /usr/local/bundle-prod --without development test && \
-RUN bundle config set --global path /usr/local/bundle && \
+RUN bundle config set --local path /usr/local/bundle && \
     bundle install -j4
 # bundle clean
 


### PR DESCRIPTION
Follow-up to #764 and fix https://app.circleci.com/pipelines/github/artsy/horizon/3888/workflows/c5dba26b-5abd-47f9-af3e-d3833a496eb8/jobs/5374, which merged with an earlier, broken version of the `--path` flag fix. `main` currently has:

```bash
RUN bundle config set --global path /usr/local/bundle && \
    bundle install -j4
```

`--global` scope writes to `/home/deploy/.bundle/config`, but the production Docker stage only copies `/app` and `/usr/local/bundle` from the builder stage — not the deploy user's home directory. So bundler in the built image doesn't know where gems are installed, and `bundle exec rake db:migrate` (the pre-deploy hook) fails with `Bundler::GemNotFound`. This is what broke the production deploy, and will also break staging deploys using this image.

Fix: use `--local` scope, which writes to `/app/.bundle/config` — and `/app` **is** copied into the production stage (`COPY --from=builder /app .`).

Verified by building the actual `production` Docker target locally from this branch and confirming `bundle exec rake -T` loads cleanly inside it.

Assisted by Claude Code Sonnet 5